### PR TITLE
Fix scheme creation bug when generating the model

### DIFF
--- a/oauthtool/Program.cs
+++ b/oauthtool/Program.cs
@@ -174,13 +174,17 @@ namespace OAuthTool
                 // add scheme of schemeType, set descriptions
                 var newScheme = new Scheme
                 {
+                    Type = schemeType,
                     RequiresAdminConsent = scheme.GetProperty("Grant").GetString() == "admin",
                     Description = scheme.GetProperty("Description").GetString(),
-                    ConsentDescription = scheme.GetProperty("CosentDescription").GetString()
+                    ConsentDescription = scheme.GetProperty("ConsentDescription").GetString()
                 };
-                if (!perm.Schemes.ContainsKey(schemeType)) {
+                if (!perm.Schemes.ContainsKey(schemeType))
+                {
                     perm.Schemes.Add(schemeType, newScheme);
-                } else {
+                }
+                else
+                {
                     Console.WriteLine($"Duplicate entry for {name} in scheme {schemeType}");
                 }
             }


### PR DESCRIPTION
Ran into an issue when generating the permissions. The scheme type always defaults to `DelegatedWork` since it's the first member of the SchemeType Enum. 
See the example:
```json
{
"$schema": "../../../../permissionsSchema.json",
    "permissions": {
      "Calendars.Read": {
        "schemes": {
          "DelegatedPersonal": {
            "type": "DelegatedWork",
            "description": "Allows the app to read events in user calendars.",
            "consentDescription": "Read user calendars"
          },
          "DelegatedWork": {
            "type": "DelegatedWork",
            "description": "Allows the app to read events in user calendars.",
            "consentDescription": "Read user calendars"
          },
          "Application": {
            "type": "DelegatedWork",
            "admin": true,
            "description": "Allows the app to read events of all calendars without a signed-in user.",
            "consentDescription": "Read calendars in all mailboxes"
            }
         }
      }
}
```

Updated scheme creation to set the type when creating the scheme.

New output:

```json
{
"$schema": "../../../../permissionsSchema.json",
  "permissions": {
    "Calendars.Read": {
      "schemes": {
        "DelegatedPersonal": {
          "type": "DelegatedPersonal",
          "description": "Allows the app to read events in user calendars.",
          "consentDescription": "Read user calendars"
        },
        "DelegatedWork": {
          "type": "DelegatedWork",
          "description": "Allows the app to read events in user calendars.",
          "consentDescription": "Read user calendars"
        },
        "Application": {
          "type": "Application",
          "admin": true,
          "description": "Allows the app to read events of all calendars without a signed-in user.",
          "consentDescription": "Read calendars in all mailboxes"
        }
     }
  }
}
```