### PR TITLE
Validate least privilege permissions

### DIFF
--- a/kibali/AuthZChecker.cs
+++ b/kibali/AuthZChecker.cs
@@ -91,9 +91,8 @@ namespace Kibali
             // Walk permissions, find each pathSet and add path to dictionary
             foreach (var permission in permissionsDocument.Permissions)
             {
-                for(int index = 0; index < permission.Value.PathSets.Count; index++ )
+                foreach(var pathSet in permission.Value.PathSets)
                 {
-                    var pathSet = permission.Value.PathSets[index];
                     foreach (var path in pathSet.Paths)
                     {
                         ProtectedResource resource;
@@ -107,7 +106,7 @@ namespace Kibali
                             resource = new ProtectedResource(path.Key);
                             resources.Add(path.Key, resource);
                         }
-                        resource.ValidateLeastPrivilegePermissions(permission.Key, pathSet, path.Value.LeastPrivilegedPermission, index);
+                        resource.ValidateLeastPrivilegePermissions(permission.Key, pathSet, path.Value.LeastPrivilegedPermission);
                         this.ContainsErrors |= resource.ContainsErrors;
                         this.Errors.UnionWith(resource.PermissionsErrors);
                     }
@@ -128,7 +127,6 @@ namespace Kibali
                         if (resources.ContainsKey(path.Key))
                         {
                             resource = resources[path.Key];
-
                         }
                         else
                         {

--- a/kibali/AuthZChecker.cs
+++ b/kibali/AuthZChecker.cs
@@ -18,6 +18,10 @@ namespace Kibali
         private readonly Dictionary<string, ProtectedResource> resources = new Dictionary<string, ProtectedResource>();
         private OpenApiUrlTreeNode urlTree;
 
+        public HashSet<PermissionsError> Errors = new HashSet<PermissionsError>();
+        
+        public bool ContainsErrors = false;
+
         public Dictionary<string, ProtectedResource> Resources { get
             {
                 return resources;
@@ -80,6 +84,35 @@ namespace Kibali
                 }
             }
             return AccessRequestResult.InsufficientPermissions;
+        }
+
+        public void Validate(PermissionsDocument permissionsDocument)
+        {
+            // Walk permissions, find each pathSet and add path to dictionary
+            foreach (var permission in permissionsDocument.Permissions)
+            {
+                for(int index = 0; index < permission.Value.PathSets.Count; index++ )
+                {
+                    var pathSet = permission.Value.PathSets[index];
+                    foreach (var path in pathSet.Paths)
+                    {
+                        ProtectedResource resource;
+                        if (resources.ContainsKey(path.Key))
+                        {
+                            resource = resources[path.Key];
+
+                        }
+                        else
+                        {
+                            resource = new ProtectedResource(path.Key);
+                            resources.Add(path.Key, resource);
+                        }
+                        resource.ValidateLeastPrivilegePermissions(permission.Key, pathSet, path.Value.LeastPrivilegedPermission, index);
+                        this.ContainsErrors |= resource.ContainsErrors;
+                        this.Errors.UnionWith(resource.PermissionsErrors);
+                    }
+                }
+            }
         }
 
         private void InvertPermissionsDocument(PermissionsDocument permissionsDocument)
@@ -196,5 +229,11 @@ namespace Kibali
         UnsupportedMethod,
         UnsupportedScheme,
         InsufficientPermissions
+    }
+
+    public enum PermissionsErrorCode
+    {
+        DuplicateLeastPrivilegeScopes,
+        InvalidLeastPrivilegeScheme,
     }
 }

--- a/kibali/PermissionsDocument.cs
+++ b/kibali/PermissionsDocument.cs
@@ -54,20 +54,8 @@ namespace Kibali
             var mergedDoc = new PermissionsDocument();
             foreach(var permissionsFile in Directory.EnumerateFiles(documentPath, "*.json"))
             {
-                try
-                {
-                    var doc = Load(new FileStream(permissionsFile, FileMode.Open));
-                    mergedDoc.Permissions = mergedDoc.Permissions.Concat(doc.Permissions).ToDictionary(x => x.Key, x => x.Value);
-                }
-                catch
-                {
-                    if (permissionsFile.EndsWith("permissionsSchema.json"))
-                    {
-                        continue;
-                    }
-                    throw;
-                }
-                
+                var doc = Load(new FileStream(permissionsFile, FileMode.Open));
+                mergedDoc.Permissions = mergedDoc.Permissions.Concat(doc.Permissions).ToDictionary(x => x.Key, x => x.Value);
             }
             return mergedDoc;
         }

--- a/kibali/PermissionsDocument.cs
+++ b/kibali/PermissionsDocument.cs
@@ -1,8 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
-using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 
 namespace Kibali
@@ -48,6 +47,29 @@ namespace Kibali
         public static PermissionsDocument Load(JsonDocument doc)
         {
             return Load(doc.RootElement);
+        }
+
+        public static PermissionsDocument LoadAndMerge(string documentPath)
+        {
+            var mergedDoc = new PermissionsDocument();
+            foreach(var permissionsFile in Directory.EnumerateFiles(documentPath, "*.json"))
+            {
+                try
+                {
+                    var doc = Load(new FileStream(permissionsFile, FileMode.Open));
+                    mergedDoc.Permissions = mergedDoc.Permissions.Concat(doc.Permissions).ToDictionary(x => x.Key, x => x.Value);
+                }
+                catch
+                {
+                    if (permissionsFile.EndsWith("permissionsSchema.json"))
+                    {
+                        continue;
+                    }
+                    throw;
+                }
+                
+            }
+            return mergedDoc;
         }
 
         public static PermissionsDocument Load(JsonElement value)

--- a/kibali/PermissionsError.cs
+++ b/kibali/PermissionsError.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace Kibali;
+
+public class PermissionsError
+{
+    public string Message { get; set; }
+
+    public string Path { get; set; }
+
+    public PermissionsErrorCode ErrorCode { get; set; }
+
+    public override bool Equals(object obj)
+    {
+        return obj is PermissionsError error &&
+               Message == error.Message &&
+               Path == error.Path &&
+               ErrorCode == error.ErrorCode;
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(Message, Path, ErrorCode);
+    }
+
+    public override string ToString()
+    {
+        return $"Kibali.PermissionsError.{this.ErrorCode};Message={this.Message};Path={this.Path};";
+    }
+}

--- a/kibali/ProtectedResource.cs
+++ b/kibali/ProtectedResource.cs
@@ -11,7 +11,6 @@ namespace Kibali
         // target -> restrictions -> schemes -> Ordered Permissions (CSDL Format) 
 
         // path -> Method -> Schemes -> Permissions  (Inverted format) 
-
         // (Path, Method) -> Schemes -> Permissions (Docs)
         // (Path, Method) -> Scheme(delegated) -> Permissions (Graph Explorer Tab)
         // Permissions(delegated) (Graph Explorer Permissions List)
@@ -53,15 +52,15 @@ namespace Kibali
             }
         }
 
-        public void ValidateLeastPrivilegePermissions(string permission, PathSet pathSet, List<string> leastPrivilegedPermissions, int index)
+        public void ValidateLeastPrivilegePermissions(string permission, PathSet pathSet, List<string> leastPrivilegedPermissions)
         {
             ComputeLeastPrivilegeEntries(permission, pathSet, leastPrivilegedPermissions);
-            ValidateMismatchedSchemes(permission, pathSet, leastPrivilegedPermissions, index);
-            ValidateDuplicatedScopes(permission, index);
+            ValidateDuplicatedScopes();
         }
 
         private void ComputeLeastPrivilegeEntries(string permission, PathSet pathSet, List<string> leastPrivilegedPermissions)
         {
+            ValidateMismatchedSchemes(permission, pathSet, leastPrivilegedPermissions);
             foreach (var supportedMethod in pathSet.Methods)
             {
                 var schemeLeastPrivilegeScopes = new Dictionary<string, HashSet<string>>();
@@ -88,7 +87,7 @@ namespace Kibali
             }
         }
 
-        private void ValidateDuplicatedScopes(string permission, int index)
+        private void ValidateDuplicatedScopes()
         {
             foreach (var methodScopes in this.leastPrivilegedPermissions)
             {
@@ -112,10 +111,10 @@ namespace Kibali
             
         }
 
-        private void ValidateMismatchedSchemes(string permission, PathSet pathSet, List<string> leastPrivilegedPermissions, int index)
+        private void ValidateMismatchedSchemes(string permission, PathSet pathSet, List<string> leastPrivilegedPermissions)
         {
             var mismatchedPrivilegeSchemes = leastPrivilegedPermissions.Except(pathSet.SchemeKeys);
-            if (mismatchedPrivilegeSchemes.Count() > 0)
+            if (mismatchedPrivilegeSchemes.Any())
             {
                 var invalidSchemes = string.Join(", ", mismatchedPrivilegeSchemes);
                 var expectedSchemes = string.Join(", ", pathSet.SchemeKeys);
@@ -136,7 +135,6 @@ namespace Kibali
                 if (existingPermissions.TryGetValue(newPermission.Key, out var existingPermission))
                 {
                     existingPermission.UnionWith(newPermission.Value);
-                    
                 }
                 else
                 {

--- a/kibali/ProtectedResource.cs
+++ b/kibali/ProtectedResource.cs
@@ -1,6 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 
 namespace Kibali
@@ -12,14 +11,19 @@ namespace Kibali
         // target -> restrictions -> schemes -> Ordered Permissions (CSDL Format) 
 
         // path -> Method -> Schemes -> Permissions  (Inverted format) 
-        
+
         // (Path, Method) -> Schemes -> Permissions (Docs)
         // (Path, Method) -> Scheme(delegated) -> Permissions (Graph Explorer Tab)
         // Permissions(delegated) (Graph Explorer Permissions List)
         // Schemas -> Permissions ( AAD Onboarding)
+        private Dictionary<string, Dictionary<string, HashSet<string>>> leastPrivilegedPermissions { get; set; } = new ();
 
         public string Url { get; set; }
-        public Dictionary<string, Dictionary<string,List<AcceptableClaim>>> SupportedMethods { get; set; } = new Dictionary<string, Dictionary<string, List<AcceptableClaim>>>();
+        public Dictionary<string, Dictionary<string, List<AcceptableClaim>>> SupportedMethods { get; set; } = new Dictionary<string, Dictionary<string, List<AcceptableClaim>>>();
+
+        public bool ContainsErrors = false;
+
+        public HashSet<PermissionsError> PermissionsErrors { get; set; } = new ();
 
         public ProtectedResource(string url)
         {
@@ -46,6 +50,98 @@ namespace Kibali
                 {
                     Update(this.SupportedMethods[supportedMethod], supportedSchemes);
                 };
+            }
+        }
+
+        public void ValidateLeastPrivilegePermissions(string permission, PathSet pathSet, List<string> leastPrivilegedPermissions, int index)
+        {
+            ComputeLeastPrivilegeEntries(permission, pathSet, leastPrivilegedPermissions);
+            ValidateMismatchedSchemes(permission, pathSet, leastPrivilegedPermissions, index);
+            ValidateDuplicatedScopes(permission, index);
+        }
+
+        private void ComputeLeastPrivilegeEntries(string permission, PathSet pathSet, List<string> leastPrivilegedPermissions)
+        {
+            foreach (var supportedMethod in pathSet.Methods)
+            {
+                var schemeLeastPrivilegeScopes = new Dictionary<string, HashSet<string>>();
+                foreach (var supportedScheme in pathSet.SchemeKeys)
+                {
+                    if (!leastPrivilegedPermissions.Contains(supportedScheme))
+                    {
+                        continue;
+                    }
+                    if (!schemeLeastPrivilegeScopes.ContainsKey(supportedScheme))
+                    {
+                        schemeLeastPrivilegeScopes.Add(supportedScheme, new HashSet<string>());
+                    }
+                    schemeLeastPrivilegeScopes[supportedScheme].Add(permission);
+                }
+                if (!this.leastPrivilegedPermissions.ContainsKey(supportedMethod))
+                {
+                    this.leastPrivilegedPermissions.Add(supportedMethod, schemeLeastPrivilegeScopes);
+                }
+                else
+                {
+                    UpdatePrivilegedPermissions(this.leastPrivilegedPermissions[supportedMethod], schemeLeastPrivilegeScopes, supportedMethod);
+                };
+            }
+        }
+
+        private void ValidateDuplicatedScopes(string permission, int index)
+        {
+            foreach (var methodScopes in this.leastPrivilegedPermissions)
+            {
+                var method = methodScopes.Key;
+                foreach (var schemeScope in methodScopes.Value)
+                {
+                    var scopes = schemeScope.Value;
+                    var scheme = schemeScope.Key;
+                    if (scopes.Count > 1)
+                    {
+                        this.PermissionsErrors.Add(new PermissionsError
+                        {
+                            Path = this.Url,
+                            ErrorCode = PermissionsErrorCode.DuplicateLeastPrivilegeScopes,
+                            Message = string.Format(StringConstants.DuplicateLeastPrivilegeSchemeErrorMessage, string.Join(", ", scopes), scheme, method),
+                        });
+                        this.ContainsErrors = true;
+                    }
+                }
+            }
+            
+        }
+
+        private void ValidateMismatchedSchemes(string permission, PathSet pathSet, List<string> leastPrivilegedPermissions, int index)
+        {
+            var mismatchedPrivilegeSchemes = leastPrivilegedPermissions.Except(pathSet.SchemeKeys);
+            if (mismatchedPrivilegeSchemes.Count() > 0)
+            {
+                var invalidSchemes = string.Join(", ", mismatchedPrivilegeSchemes);
+                var expectedSchemes = string.Join(", ", pathSet.SchemeKeys);
+                this.PermissionsErrors.Add(new PermissionsError
+                {
+                    Path = this.Url,
+                    ErrorCode = PermissionsErrorCode.InvalidLeastPrivilegeScheme,
+                    Message = string.Format(StringConstants.UnexpectedLeastPrivilegeSchemeErrorMessage, invalidSchemes, permission, expectedSchemes),
+                });
+                this.ContainsErrors = true;
+            }
+        }
+
+        private void UpdatePrivilegedPermissions(Dictionary<string, HashSet<string>> existingPermissions, Dictionary<string, HashSet<string>> newPermissions, string method)
+        {
+            foreach (var newPermission in newPermissions)
+            {
+                if (existingPermissions.TryGetValue(newPermission.Key, out var existingPermission))
+                {
+                    existingPermission.UnionWith(newPermission.Value);
+                    
+                }
+                else
+                {
+                    existingPermissions[newPermission.Key] = newPermission.Value;
+                }
             }
         }
 
@@ -108,4 +204,6 @@ namespace Kibali
             writer.WriteEndArray();
         }
     }
+
+    
 }

--- a/kibali/StringConstants.cs
+++ b/kibali/StringConstants.cs
@@ -1,0 +1,8 @@
+﻿namespace Kibali;
+
+public class StringConstants
+{
+    internal const string UnexpectedLeastPrivilegeSchemeErrorMessage = "Unexpected Least Privilege Scheme '{0}' for scope '{1}'. Expected Schemes: {2}";
+
+    internal const string DuplicateLeastPrivilegeSchemeErrorMessage = "Duplicate Least Privilege Scopes {0} for Scheme '{1}' for Method '{2}' ";
+}

--- a/kibaliTests/InvalidPermissions/Directory.json
+++ b/kibaliTests/InvalidPermissions/Directory.json
@@ -1,0 +1,1429 @@
+{
+  "$schema": "https://microsoftgraph.github.io/msgraph-metadata/graph-permissions-schema.json",
+  "permissions": {
+    "Directory.AccessAsUser.All": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Access directory as the signed in user",
+          "adminDescription": "Allows the app to have the same access to information in the directory as the signed-in user.",
+          "userDisplayName": "Access the directory as you",
+          "userDescription": "Allows the app to have the same access to information in your work or school directory as you do.",
+          "requiresAdminConsent": true
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/devices": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/devices/{id}/registeredowners": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/devices/{id}/registeredusers": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/privilegedapproval": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/changepassword": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/privilegedroleassignments/{id}/makeeligible": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/privilegedroleassignments/{id}/makepermanent": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/privilegedroles/{id}/selfactivate": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/privilegedroles/{id}/selfdeactivate": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/changepassword": {}
+          }
+        },
+        {
+          "methods": [
+            "PATCH",
+            "DELETE"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/devices/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/devices/{id}/registeredowners/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/devices/{id}/registeredusers/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE",
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/privilegedroleassignments/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/privilegedapproval/myrequests": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/privilegedoperationevents": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/privilegedroleassignments/my": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/privilegedroleassignments/{id}/roleinfo": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/privilegedroles": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/privilegedroles/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/privilegedroles/{id}/assignments": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/privilegedroles/{id}/settings": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/privilegedroleassignments": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        }
+      ],
+      "ownerEmail": ""
+    },
+    "Directory.Read.All": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Read directory data",
+          "adminDescription": "Allows the app to read data in your organization\u0027s directory, such as users, groups and apps.",
+          "userDisplayName": "Read directory data",
+          "userDescription": "Allows the app to read data in your organization\u0027s directory.",
+          "requiresAdminConsent": true
+        },
+        "Application": {
+          "adminDisplayName": "Read directory data",
+          "adminDescription": "Allows the app to read data in your organization\u0027s directory, such as users, groups and apps, without a signed-in user.",
+          "requiresAdminConsent": true
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/administrativeunits": {},
+            "/administrativeunits/{id}": {},
+            "/administrativeunits/{id}/members": {},
+            "/administrativeunits/{id}/members/{id}": {},
+            "/directory/administrativeunits": {},
+            "/directory/administrativeunits/{id}": {},
+            "/groups/{id}/approleassignments": {},
+            "/users/{id}/approleassignments": {},
+            "/serviceprincipals/{id}/approleassignments": {},
+            "/applications": {},
+            "/applications/delta": {},
+            "/applications/{id}": {},
+            "/applications/{id}/extensionproperties": {},
+            "/directory/deleteditems/microsoft.graph.application": {},
+            "/directory/deleteditems/microsoft.graph.group": {},
+            "/directory/deleteditems/microsoft.graph.serviceprincipal": {},
+            "/directory/deleteditems/microsoft.graph.user": {},
+            "/directory/deleteditems/{id}": {},
+            "/policies/claimsmappingpolicies/{id}/appliesto": {},
+            "/policies/homerealmdiscoverypolicies/{id}/appliesto": {},
+            "/policies/tokenissuancepolicies/{id}/appliesto": {},
+            "/policies/tokenlifetimepolicies/{id}/appliesto": {},
+            "/serviceprincipals/delta": {},
+            "/serviceprincipals/{id}": {},
+            "/serviceprincipals/{id}/createdobjects": {},
+            "/serviceprincipals/{id}/delegatedpermissionclassifications": {},
+            "/serviceprincipals/{id}/memberof": {},
+            "/serviceprincipals/{id}/ownedobjects": {},
+            "/serviceprincipals/{id}/transitivememberof": {},
+            "/directoryobjects/{id}": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals": {},
+            "/auditlogs/directoryaudits": {},
+            "/auditlogs/directoryaudits/{id}": {},
+            "/auditlogs/provisioning": {},
+            "/auditlogs/signins": {},
+            "/auditlogs/signins/{id}": {},
+            "/teams/{id}/channels": {},
+            "/teams/{id}/channels/{id}": {},
+            "/rolemanagement/cloudpc/roledefinitions": {},
+            "/rolemanagement/cloudpc/roledefinitions/{id}": {},
+            "/rolemanagement/devicemanagement/roledefinitions": {},
+            "/rolemanagement/devicemanagement/roledefinitions/{id}": {},
+            "/rolemanagement/directory/roledefinitions": {},
+            "/rolemanagement/directory/roledefinitions/{id}": {},
+            "/rolemanagement/entitlementmanagement/roledefinitions": {},
+            "/rolemanagement/entitlementmanagement/roledefinitions/{id}": {},
+            "/oauth2permissiongrants/{id}": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/me/oauth2permissiongrants": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/oauth2permissiongrants": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/oauth2permissiongrants": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/oauth2permissiongrants": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/devices": {},
+            "/devices/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/devices/{id}/memberof": {},
+            "/devices/{id}/registeredowners": {},
+            "/devices/{id}/registeredusers": {},
+            "/devices/{id}/transitivememberof": {},
+            "/devices/{id}/usagerights": {},
+            "/organization": {},
+            "/administrativeunits/{id}/scopedrolemembers": {},
+            "/administrativeunits/{id}/scopedrolemembers/{id}": {},
+            "/contacts": {},
+            "/contacts/delta": {},
+            "/contacts/{id}": {},
+            "/contacts/{id}/directreports": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/contacts/{id}/manager": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/contacts/{id}/memberof": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/contacts/{id}/transitivereports/$count": {},
+            "/contracts": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/contracts/{id}": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/dataclassification/jobs": {},
+            "/dataclassification/jobs/{id}": {},
+            "/dataclassification/sensitivetypes": {},
+            "/dataclassification/sensitivetypes/{id}": {},
+            "/directoryroles": {},
+            "/directoryroles/delta": {},
+            "/directoryroles/roletemplateid={roletemplateid}": {},
+            "/directoryroles/roletemplateid={roletemplateid}/members": {},
+            "/directoryroles/roletemplateid={roletemplateid}/scopedmembers": {},
+            "/directoryroles/{id}": {},
+            "/directoryroles/{id}/members": {},
+            "/directoryroles/{id}/scopedmembers": {},
+            "/directoryroletemplates": {},
+            "/directoryroletemplates/{id}": {},
+            "/directorysettingtemplates": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/directorysettingtemplates/{id}": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/domains": {},
+            "/domains/{id}": {},
+            "/education/classes/{id}/group": {},
+            "/education/me/user": {},
+            "/education/schools/{id}/administrativeunit": {},
+            "/education/users/{id}/user": {},
+            "/grouplifecyclepolicies": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/grouplifecyclepolicies/{id}": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/groups": {},
+            "/groups/delta": {},
+            "/groups/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/groups/{id}/grouplifecyclepolicies": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/groups/{id}/memberof": {},
+            "/groups/{id}/members": {},
+            "/groups/{id}/owners": {},
+            "/groups/{id}/settings": {},
+            "/groups/{id}/settings/{id}": {},
+            "/groups/{id}/transitivememberof": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/groups/{id}/transitivemembers": {},
+            "/groupsettings": {},
+            "/groupsettings/{id}": {},
+            "/me": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/me/createdobjects": {},
+            "/me/directreports": {},
+            "/me/joinedteams": {},
+            "/me/licensedetails": {},
+            "/me/manager": {},
+            "/me/memberof": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/ownedobjects": {},
+            "/me/registereddevices": {},
+            "/me/scopedrolememberof": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/policies/adminconsentrequestpolicy": {},
+            "/policies/permissiongrantpolicies/{id}/excludes": {},
+            "/policies/permissiongrantpolicies/{id}/includes": {},
+            "/rolemanagement/directory/roleassignments": {},
+            "/rolemanagement/directory/roleassignments/{id}": {},
+            "/rolemanagement/directory/transitiveroleassignments": {},
+            "/rolemanagement/entitlementmanagement/roleassignments": {},
+            "/rolemanagement/entitlementmanagement/roleassignments/{id}": {},
+            "/settings": {},
+            "/settings/{id}": {},
+            "/subscribedskus": {},
+            "/subscribedskus/{id}": {},
+            "/teams/{id}": {},
+            "/teams/{id}/channels/{id}/tabs": {},
+            "/teams/{id}/channels/{id}/tabs/{id}": {},
+            "/teams/{id}/installedapps": {},
+            "/teams/{id}/installedapps/{id}": {},
+            "/users": {},
+            "/users/delta": {},
+            "/users/{id}": {},
+            "/users/{id}/createdobjects": {},
+            "/users/{id}/directreports": {},
+            "/users/{id}/joinedteams": {},
+            "/users/{id}/licensedetails": {},
+            "/users/{id}/manager": {},
+            "/users/{id}/memberof": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/owneddevices": {},
+            "/users/{id}/ownedobjects": {},
+            "/users/{id}/registereddevices": {},
+            "/users/{id}/scopedrolememberof": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/transitivememberof": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/transitivereports/$count": {},
+            "/users/{id}/usagerights": {}
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/appcatalogs/teamsapps": {},
+            "/applications/{id}/extensionproperties/{id}": {},
+            "/applications/{id}/synchronization/templates/{id}/schema": {},
+            "/serviceprincipals/{id}/synchronization/jobs/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/synchronization/jobs/{id}/schema": {},
+            "/applications/{id}/synchronization/templates": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/applications/{id}/synchronization/templates/{id}": {},
+            "/applications/{id}/synchronization/templates/{id}/schema/filteroperators": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/applications/{id}/synchronization/templates/{id}/schema/functions": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/synchronization/jobs/{id}/schema/filteroperators": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/synchronization/jobs/{id}/schema/functions": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/synchronization/templates": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/synchronization/templates/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/synchronization/templates/{id}/schema": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/synchronization/templates/{id}/schema/filteroperators": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/synchronization/templates/{id}/schema/functions": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/privilegedroleassignmentrequests": {},
+            "/administrativeunits/delta": {},
+            "/oauth2permissiongrants/delta": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST",
+            "GET"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/serviceprincipals/{id}/approleassignedto": {},
+            "/applications/{id}/owners": {},
+            "/serviceprincipals/{id}/owners": {}
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/contacts/{id}/checkmembergroups": {},
+            "/contacts/{id}/checkmemberobjects": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/contacts/{id}/getmembergroups": {},
+            "/contacts/{id}/getmemberobjects": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/devices/{id}/checkmembergroups": {},
+            "/devices/{id}/checkmemberobjects": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/devices/{id}/getmembergroups": {},
+            "/devices/{id}/getmemberobjects": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/directoryobjects/{id}/checkmembergroups": {},
+            "/directoryobjects/{id}/checkmemberobjects": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/directoryobjects/{id}/getmembergroups": {},
+            "/directoryobjects/{id}/getmemberobjects": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/groups/{id}/checkmembergroups": {},
+            "/groups/{id}/checkmemberobjects": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/groups/{id}/getmembergroups": {},
+            "/groups/{id}/getmemberobjects": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/me/checkmembergroups": {},
+            "/me/checkmemberobjects": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/me/getmembergroups": {},
+            "/me/getmemberobjects": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/checkmembergroups": {},
+            "/serviceprincipals/{id}/checkmemberobjects": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/getmembergroups": {},
+            "/serviceprincipals/{id}/getmemberobjects": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/checkmembergroups": {},
+            "/users/{id}/checkmemberobjects": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/getmembergroups": {},
+            "/users/{id}/getmemberobjects": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/createpasswordsinglesignoncredentials": {},
+            "/serviceprincipals/{id}/deletepasswordsinglesignoncredentials": {},
+            "/serviceprincipals/{id}/getpasswordsinglesignoncredentials": {},
+            "/serviceprincipals/{id}/updatepasswordsinglesignoncredentials": {},
+            "/dataclassification/classifyfile": {},
+            "/dataclassification/classifytext": {},
+            "/directoryobjects/getbyids": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/directoryobjects/validateproperties": {}
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/groups/evaluatedynamicmembership": {},
+            "/groups/{id}/evaluatedynamicmembership": {},
+            "/privilegedroleassignmentrequests/my": {}
+          }
+        }
+      ],
+      "ownerEmail": ""
+    },
+    "Directory.ReadWrite.All": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Read and write directory data",
+          "adminDescription": "Allows the app to read and write data in your organization\u0027s directory, such as users, and groups.  It does not allow the app to delete users or groups, or reset user passwords.",
+          "userDisplayName": "Read and write directory data",
+          "userDescription": "Allows the app to read and write data in your organization\u0027s directory, such as other users, groups.  It does not allow the app to delete users or groups, or reset user passwords.",
+          "requiresAdminConsent": true
+        },
+        "Application": {
+          "adminDisplayName": "Read and write directory data",
+          "adminDescription": "Allows the app to read and write data in your organization\u0027s directory, such as users, and groups, without a signed-in user.  Does not allow user or group deletion.",
+          "requiresAdminConsent": true
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/administrativeunits": {},
+            "/administrativeunits/{id}": {},
+            "/administrativeunits/{id}/members/{id}": {},
+            "/directory/administrativeunits": {},
+            "/directory/administrativeunits/{id}": {},
+            "/groups/{id}/approleassignments": {},
+            "/applications/delta": {},
+            "/directory/deleteditems/microsoft.graph.application": {},
+            "/directory/deleteditems/microsoft.graph.group": {},
+            "/directory/deleteditems/microsoft.graph.serviceprincipal": {},
+            "/directory/deleteditems/microsoft.graph.user": {},
+            "/serviceprincipals/delta": {},
+            "/serviceprincipals/{id}/createdobjects": {},
+            "/serviceprincipals/{id}/memberof": {},
+            "/serviceprincipals/{id}/ownedobjects": {},
+            "/serviceprincipals/{id}/transitivememberof": {},
+            "/rolemanagement/entitlementmanagement/roledefinitions": {},
+            "/rolemanagement/entitlementmanagement/roledefinitions/{id}": {},
+            "/serviceprincipals/{id}/oauth2permissiongrants": {},
+            "/devices": {},
+            "/devices/{id}/memberof": {},
+            "/devices/{id}/registeredowners": {},
+            "/devices/{id}/registeredusers": {},
+            "/devices/{id}/transitivememberof": {},
+            "/devices/{id}/usagerights": {},
+            "/organization": {},
+            "/administrativeunits/{id}/scopedrolemembers": {},
+            "/administrativeunits/{id}/scopedrolemembers/{id}": {},
+            "/contacts": {},
+            "/contacts/delta": {},
+            "/contacts/{id}": {},
+            "/contacts/{id}/directreports": {},
+            "/contacts/{id}/manager": {},
+            "/contacts/{id}/memberof": {},
+            "/contracts": {},
+            "/contracts/{id}": {},
+            "/directoryroles": {},
+            "/directoryroles/delta": {},
+            "/directoryroles/roletemplateid={roletemplateid}": {},
+            "/directoryroles/roletemplateid={roletemplateid}/members": {},
+            "/directoryroles/roletemplateid={roletemplateid}/scopedmembers": {},
+            "/directoryroles/{id}": {},
+            "/directoryroles/{id}/members": {},
+            "/directoryroles/{id}/scopedmembers": {},
+            "/directoryroletemplates": {},
+            "/directoryroletemplates/{id}": {},
+            "/directorysettingtemplates": {},
+            "/directorysettingtemplates/{id}": {},
+            "/groups/delta": {},
+            "/groups/{id}/grouplifecyclepolicies": {},
+            "/groups/{id}/memberof": {},
+            "/groups/{id}/transitivememberof": {},
+            "/me": {},
+            "/me/createdobjects": {},
+            "/me/directreports": {},
+            "/me/joinedteams": {},
+            "/me/licensedetails": {},
+            "/me/manager": {},
+            "/me/memberof": {},
+            "/me/ownedobjects": {},
+            "/me/registereddevices": {},
+            "/me/scopedrolememberof": {},
+            "/rolemanagement/directory/roleassignments": {},
+            "/rolemanagement/directory/roleassignments/{id}": {},
+            "/rolemanagement/directory/transitiveroleassignments": {},
+            "/rolemanagement/entitlementmanagement/roleassignments": {},
+            "/rolemanagement/entitlementmanagement/roleassignments/{id}": {},
+            "/subscribedskus": {},
+            "/subscribedskus/{id}": {},
+            "/users/delta": {},
+            "/users/{id}/createdobjects": {},
+            "/users/{id}/directreports": {},
+            "/users/{id}/joinedteams": {},
+            "/users/{id}/licensedetails": {},
+            "/users/{id}/memberof": {},
+            "/users/{id}/owneddevices": {},
+            "/users/{id}/ownedobjects": {},
+            "/users/{id}/registereddevices": {},
+            "/users/{id}/scopedrolememberof": {},
+            "/users/{id}/transitivememberof": {},
+            "/users/{id}/usagerights": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/administrativeunits/{id}/members": {},
+            "/serviceprincipals/{id}/approleassignedto": {},
+            "/serviceprincipals/{id}/approleassignments": {},
+            "/applications": {},
+            "/applications/{id}/extensionproperties": {},
+            "/applications/{id}/owners": {},
+            "/serviceprincipals/{id}/owners": {},
+            "/serviceprincipals": {},
+            "/serviceprincipals/{id}/synchronization/jobs": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/teams/{id}/channels": {},
+            "/rolemanagement/cloudpc/roledefinitions": {},
+            "/rolemanagement/devicemanagement/roledefinitions": {},
+            "/rolemanagement/directory/roledefinitions": {},
+            "/oauth2permissiongrants": {},
+            "/grouplifecyclepolicies": {},
+            "/groups": {},
+            "/groups/{id}/settings": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/settings": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/teams/{id}/channels/{id}/tabs": {},
+            "/teams/{id}/installedapps": {},
+            "/users": {},
+            "/onpremisespublishingprofiles/applicationproxy/connectorgroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/appcatalogs/teamsapps": {},
+            "/onpremisespublishingprofiles/applicationproxy/connectorgroups/{id}/members": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/onpremisespublishingprofiles/applicationproxy/connectors/{id}/memberof": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/policies/featurerolloutpolicies": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "DELETE",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/applications/{id}": {},
+            "/serviceprincipals/{id}": {},
+            "/teams/{id}/channels/{id}": {},
+            "/rolemanagement/cloudpc/roledefinitions/{id}": {},
+            "/rolemanagement/devicemanagement/roledefinitions/{id}": {},
+            "/rolemanagement/directory/roledefinitions/{id}": {},
+            "/oauth2permissiongrants/{id}": {},
+            "/grouplifecyclepolicies/{id}": {},
+            "/groups/{id}/settings/{id}": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/settings/{id}": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/teams/{id}/channels/{id}/tabs/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/applications/{id}/extensionproperties/{id}": {},
+            "/applications/{id}/owners/{id}": {},
+            "/serviceprincipals/{id}/owners/{id}": {},
+            "/groups/{id}/members/{id}": {},
+            "/groups/{id}/owners/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "DELETE"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/directory/deleteditems/{id}": {},
+            "/serviceprincipals/{id}/synchronization/jobs/{id}": {},
+            "/teams/{id}/installedapps/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application"
+          ],
+          "paths": {
+            "/schemaextensions": {}
+          }
+        },
+        {
+          "methods": [
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "Application"
+          ],
+          "paths": {
+            "/schemaextensions/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/contacts/{id}/checkmembergroups": {},
+            "/contacts/{id}/checkmemberobjects": {},
+            "/contacts/{id}/getmembergroups": {},
+            "/contacts/{id}/getmemberobjects": {},
+            "/devices/{id}/checkmembergroups": {},
+            "/devices/{id}/checkmemberobjects": {},
+            "/devices/{id}/getmembergroups": {},
+            "/devices/{id}/getmemberobjects": {},
+            "/directoryobjects/{id}/checkmembergroups": {},
+            "/directoryobjects/{id}/checkmemberobjects": {},
+            "/directoryobjects/{id}/getmembergroups": {},
+            "/directoryobjects/{id}/getmemberobjects": {},
+            "/groups/{id}/checkmembergroups": {},
+            "/groups/{id}/checkmemberobjects": {},
+            "/groups/{id}/getmembergroups": {},
+            "/groups/{id}/getmemberobjects": {},
+            "/me/checkmembergroups": {},
+            "/me/checkmemberobjects": {},
+            "/me/getmembergroups": {},
+            "/me/getmemberobjects": {},
+            "/serviceprincipals/{id}/checkmembergroups": {},
+            "/serviceprincipals/{id}/checkmemberobjects": {},
+            "/serviceprincipals/{id}/getmembergroups": {},
+            "/serviceprincipals/{id}/getmemberobjects": {},
+            "/users/{id}/checkmembergroups": {},
+            "/users/{id}/checkmemberobjects": {},
+            "/users/{id}/getmembergroups": {},
+            "/users/{id}/getmemberobjects": {},
+            "/applications/{id}/addpassword": {},
+            "/applications/{id}/removepassword": {},
+            "/applicationtemplates/{id}/instantiate": {},
+            "/serviceprincipals/{id}/addkey": {},
+            "/serviceprincipals/{id}/addpassword": {},
+            "/serviceprincipals/{id}/addtokensigningcertificate": {},
+            "/serviceprincipals/{id}/createpasswordsinglesignoncredentials": {},
+            "/serviceprincipals/{id}/deletepasswordsinglesignoncredentials": {},
+            "/serviceprincipals/{id}/getpasswordsinglesignoncredentials": {},
+            "/serviceprincipals/{id}/removekey": {},
+            "/serviceprincipals/{id}/removepassword": {},
+            "/serviceprincipals/{id}/updatepasswordsinglesignoncredentials": {},
+            "/applications/{id}/synchronization/acquireaccesstoken": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/synchronization/acquireaccesstoken": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/synchronization/jobs/{id}/pause": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/synchronization/jobs/{id}/provisionondemand": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/synchronization/jobs/{id}/restart": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/synchronization/jobs/{id}/schema/directories/{id}/discover": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/synchronization/jobs/{id}/schema/parseexpression": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/synchronization/jobs/{id}/start": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/synchronization/jobs/{id}/validatecredentials": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/synchronization/templates/{id}/schema/parseexpression": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/groups/{id}/members": {},
+            "/groups/{id}/owners": {},
+            "/groupsettings": {},
+            "/directoryobjects/validateproperties": {},
+            "/grouplifecyclepolicies/renewgroup": {},
+            "/grouplifecyclepolicies/{id}/addgroup": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/grouplifecyclepolicies/{id}/removegroup": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/groups/{id}/assignlicense": {},
+            "/groups/{id}/renew": {},
+            "/invitations": {},
+            "/me/revokesigninsessions": {},
+            "/organization/{id}/activateservice": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/teams": {},
+            "/teams/87654321-0abc-zqf0-321456789q/installedapps": {},
+            "/teams/{id}/archive": {},
+            "/teams/{id}/clone": {},
+            "/teams/{id}/installedapps/{id}/upgrade": {},
+            "/teams/{id}/unarchive": {},
+            "/users/{id}/activateserviceplan": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/assignlicense": {},
+            "/users/{id}/reprocesslicenseassignment": {},
+            "/users/{id}/revokesigninsessions": {}
+          }
+        },
+        {
+          "methods": [
+            "DELETE",
+            "GET",
+            "PUT"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/applications/{id}/synchronization/templates/{id}/schema": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/synchronization/jobs/{id}/schema": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "Application"
+          ],
+          "paths": {
+            "/applications/{id}/synchronization/templates": {},
+            "/applications/{id}/synchronization/templates/{id}/schema/filteroperators": {},
+            "/applications/{id}/synchronization/templates/{id}/schema/functions": {},
+            "/serviceprincipals/{id}/synchronization/jobs/{id}/schema/filteroperators": {},
+            "/serviceprincipals/{id}/synchronization/jobs/{id}/schema/functions": {},
+            "/serviceprincipals/{id}/synchronization/templates": {},
+            "/serviceprincipals/{id}/synchronization/templates/{id}": {},
+            "/serviceprincipals/{id}/synchronization/templates/{id}/schema": {},
+            "/serviceprincipals/{id}/synchronization/templates/{id}/schema/filteroperators": {},
+            "/serviceprincipals/{id}/synchronization/templates/{id}/schema/functions": {},
+            "/group/{id}/settings": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/applications/{id}/synchronization/templates/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/devices/{id}": {},
+            "/groups/{id}": {},
+            "/teams/{id}": {},
+            "/users/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "PUT"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/serviceprincipals/{id}/synchronization/secrets": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/groups/{id}/team": {}
+          }
+        },
+        {
+          "methods": [
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/teams/{id}/channels/{id}/members/{id}": {},
+            "/teams/{id}/members/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "DELETE",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/groupsettings/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "PUT"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/policies/adminconsentrequestpolicy": {},
+            "/users/{id}/manager": {}
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/appcatalogs/teamsapps/{id}": {},
+            "/appcatalogs/teamsapps/{id}/appdefinitions/{id}": {},
+            "/onpremisespublishingprofiles/{id}/agents/{id}/agentgroups/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/policies/featurerolloutpolicies/{id}/appliesto/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE",
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/onpremisespublishingprofiles/applicationproxy/connectorgroups/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/policies/featurerolloutpolicies/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE",
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/onpremisespublishingprofiles/{id}/agentgroups/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/onpremisespublishingprofiles/applicationproxy/connectorgroups/{id}/applications": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/onpremisespublishingprofiles/applicationproxy/connectors": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/onpremisespublishingprofiles/applicationproxy/connectors/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/onpremisespublishingprofiles/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/onpremisespublishingprofiles/{id}/agents": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/onpremisespublishingprofiles/{id}/agents/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/administrativeunits/delta": {},
+            "/oauth2permissiongrants/delta": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/onpremisespublishingprofiles/{id}/agentgroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/onpremisespublishingprofiles/{id}/hybridagentupdaterconfiguration": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/appcatalogs/teamsapps/{id}/appdefinitions": {},
+            "/me/invalidateallrefreshtokens": {},
+            "/onpremisespublishingprofiles/{id}/agentgroups/{id}/agents": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/onpremisespublishingprofiles/{id}/agents/{id}/agentgroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/policies/featurerolloutpolicies/{id}/appliesto": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/invalidateallrefreshtokens": {}
+          }
+        },
+        {
+          "methods": [
+            "PUT"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/applications/{id}/connectorgroup": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        }
+      ],
+      "ownerEmail": ""
+    }
+  }
+}

--- a/kibaliTests/InvalidPermissions/User.json
+++ b/kibaliTests/InvalidPermissions/User.json
@@ -1,0 +1,2794 @@
+{
+  "$schema": "https://microsoftgraph.github.io/msgraph-metadata/graph-permissions-schema.json",
+  "permissions": {
+    "User.Export.All": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Export user\u0027s data",
+          "adminDescription": "Allows the app to export data (e.g. customer content or system-generated logs), associated with any user in your company, when the app is used by a privileged user (e.g. a Company Administrator).",
+          "userDisplayName": "Export user\u0027s data",
+          "userDescription": "Allows the app to export data (e.g. customer content or system-generated logs), associated with any user in your company, when the app is used by a privileged user (e.g. a Company Administrator).",
+          "requiresAdminConsent": true
+        },
+        "Application": {
+          "adminDisplayName": "Export user\u0027s data",
+          "adminDescription": "Allows the app to export data (e.g. customer content or system-generated logs), associated with any user in your company, when the app is used by a privileged user (e.g. a Company Administrator).",
+          "requiresAdminConsent": true
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/datapolicyoperations/{id}": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/{id}/exportpersonaldata": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            }
+          }
+        }
+      ],
+      "ownerEmail": ""
+    },
+    "User.Invite.All": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Invite guest users to the organization",
+          "adminDescription": "Allows the app to invite guest users to the organization, on behalf of the signed-in user.",
+          "userDisplayName": "Invite guest users to the organization",
+          "userDescription": "Allows the app to invite guest users to the organization, on your behalf.",
+          "requiresAdminConsent": true
+        },
+        "Application": {
+          "adminDisplayName": "Invite guest users to the organization",
+          "adminDescription": "Allows the app to invite guest users to the organization, without a signed-in user.",
+          "requiresAdminConsent": true
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/invitations": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            }
+          }
+        }
+      ],
+      "ownerEmail": ""
+    },
+    "User.ManageIdentities.All": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Manage  user identities",
+          "adminDescription": "Allows the app to read, update and delete identities that are associated with a user\u0027s account that the signed-in user has access to. This controls the identities users can sign-in with.",
+          "userDisplayName": "Manage  user identities",
+          "userDescription": "Allows the app to read, update and delete identities that are associated with a user\u0027s account that you have access to. This controls the identities users can sign-in with.",
+          "requiresAdminConsent": true
+        },
+        "Application": {
+          "adminDisplayName": "Manage all users\u0027 identities",
+          "adminDescription": "Allows the app to read, update and delete identities that are associated with a user\u0027s account, without a signed in user. This controls the identities users can sign-in with.",
+          "requiresAdminConsent": true
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/{id}": {}
+          }
+        }
+      ],
+      "ownerEmail": ""
+    },
+    "User.Read": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Sign in and read user profile",
+          "adminDescription": "Allows users to sign-in to the app, and allows the app to read the profile of signed-in users. It also allows the app to read basic company information of signed-in users.",
+          "userDisplayName": "Sign you in and read your profile",
+          "userDescription": "Allows you to sign in to the app with your organizational account and let the app read your profile. It also allows the app to read basic company information.",
+          "requiresAdminConsent": false
+        },
+        "DelegatedPersonal": {
+          "adminDisplayName": "Sign in and read user profile",
+          "adminDescription": "Allows users to sign-in to the app, and allows the app to read the profile of signed-in users. It also allows the app to read basic company information of signed-in users.",
+          "userDisplayName": "Sign you in and read your profile",
+          "userDescription": "Allows you to sign in to the app with your organizational account and let the app read your profile. It also allows the app to read basic company information.",
+          "requiresAdminConsent": false
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/applications": {}
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/schemaextensions": {},
+            "/schemaextensions/{id}": {},
+            "/organization": {},
+            "/education/me/user": {},
+            "/education/users/{id}/user": {},
+            "/me/directreports": {},
+            "/me/memberof": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/ownedobjects": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/registereddevices": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/delta": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/memberof": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/ownedobjects": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/registereddevices": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/transitivememberof": {},
+            "/users/{id}/usagerights": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/drive": {},
+            "/me/drives": {},
+            "/organization/{id}/branding": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/organization/{id}/branding/localizations/{id}": {},
+            "/me/analytics/settings": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/settings/contactmergesuggestions": {},
+            "/me/settings/iteminsights": {},
+            "/organization/{id}/branding/localizations": {},
+            "/users/{id}/analytics/settings": {},
+            "/users/{id}/settings/contactmergesuggestions": {},
+            "/users/{id}/settings/iteminsights": {},
+            "/me/findmeetingtimes": {},
+            "/me/findroomlists": {},
+            "/me/findrooms": {},
+            "/me/memberof/{id}": {},
+            "/me/settings": {},
+            "/users/{id}/accountenabled": {},
+            "/users/{id}/agegroup": {},
+            "/users/{id}/assignedlicenses": {},
+            "/users/{id}/assignedplans": {},
+            "/users/{id}/businessphones": {},
+            "/users/{id}/city": {},
+            "/users/{id}/companyname": {},
+            "/users/{id}/consentprovidedforminor": {},
+            "/users/{id}/country": {},
+            "/users/{id}/createddatetime": {},
+            "/users/{id}/creationtype": {},
+            "/users/{id}/deleteddatetime": {},
+            "/users/{id}/department": {},
+            "/users/{id}/devicekeys": {},
+            "/users/{id}/employeeid": {},
+            "/users/{id}/externaluserstate": {},
+            "/users/{id}/externaluserstatechangedatetime": {},
+            "/users/{id}/faxnumber": {},
+            "/users/{id}/imaddresses": {},
+            "/users/{id}/isresourceaccount": {},
+            "/users/{id}/jobtitle": {},
+            "/users/{id}/legalagegroupclassification": {},
+            "/users/{id}/mailnickname": {},
+            "/users/{id}/memberof/{id}": {},
+            "/users/{id}/mobilephone": {},
+            "/users/{id}/officelocation": {},
+            "/users/{id}/onpremisesdistinguishedname": {},
+            "/users/{id}/onpremisesdomainname": {},
+            "/users/{id}/onpremisesextensionattributes": {},
+            "/users/{id}/onpremisesimmutableid": {},
+            "/users/{id}/onpremiseslastsyncdatetime": {},
+            "/users/{id}/onpremisesprovisioningerrors": {},
+            "/users/{id}/onpremisessamaccountname": {},
+            "/users/{id}/onpremisessecurityidentifier": {},
+            "/users/{id}/onpremisessyncenabled": {},
+            "/users/{id}/onpremisesuserprincipalname": {},
+            "/users/{id}/othermails": {},
+            "/users/{id}/passwordpolicies": {},
+            "/users/{id}/passwordprofile": {},
+            "/users/{id}/photo": {},
+            "/users/{id}/photos": {},
+            "/users/{id}/photos/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/postalcode": {},
+            "/users/{id}/preferreddatalocation": {},
+            "/users/{id}/provisionedplans": {},
+            "/users/{id}/proxyaddresses": {},
+            "/users/{id}/refreshtokensvalidfromdatetime": {},
+            "/users/{id}/showinaddresslist": {},
+            "/users/{id}/signinsessionsvalidfromdatetime": {},
+            "/users/{id}/state": {},
+            "/users/{id}/streetaddress": {},
+            "/users/{id}/usagelocation": {},
+            "/users/{id}/usertype": {},
+            "/me/exportpersonaldata": {},
+            "/me/extensions": {},
+            "/me/onenote": {},
+            "/me/outlook": {},
+            "/me/owneddevices": {},
+            "/me/photo": {},
+            "/me/photos": {},
+            "/me/photos/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/contacts/{id}/checkmemberobjects": {},
+            "/contacts/{id}/getmemberobjects": {},
+            "/devices/{id}/checkmemberobjects": {},
+            "/devices/{id}/getmemberobjects": {},
+            "/directoryobjects/{id}/checkmemberobjects": {},
+            "/directoryobjects/{id}/getmemberobjects": {},
+            "/groups/{id}/checkmemberobjects": {},
+            "/groups/{id}/getmemberobjects": {},
+            "/me/checkmemberobjects": {},
+            "/me/getmemberobjects": {},
+            "/serviceprincipals/{id}/checkmemberobjects": {},
+            "/serviceprincipals/{id}/getmemberobjects": {},
+            "/users/{id}/checkmemberobjects": {},
+            "/users/{id}/getmemberobjects": {}
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/createdobjects": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/licensedetails": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}": {},
+            "/users/{id}/createdobjects": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/licensedetails": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/outlook/supportedlanguages": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/outlook/supportedtimezones": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/outlook/supportedtimezones(timezonestandard={value})": {},
+            "/me/profile": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/account": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/account/{id}": {},
+            "/me/profile/addresses": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/addresses/{id}": {},
+            "/me/profile/anniversaries": {},
+            "/me/profile/anniversaries/{id}": {},
+            "/me/profile/awards": {},
+            "/me/profile/awards/{id}": {},
+            "/me/profile/certifications": {},
+            "/me/profile/certifications/{id}": {},
+            "/me/profile/educationalactivities": {},
+            "/me/profile/educationalactivities/{id}": {},
+            "/me/profile/emails": {},
+            "/me/profile/emails/{id}": {},
+            "/me/profile/interests": {},
+            "/me/profile/interests/{id}": {},
+            "/me/profile/languages": {},
+            "/me/profile/languages/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/names/{id}": {},
+            "/me/profile/notes": {},
+            "/me/profile/patents": {},
+            "/me/profile/patents/{id}": {},
+            "/me/profile/phones": {},
+            "/me/profile/phones/{id}": {},
+            "/me/profile/positions": {},
+            "/me/profile/positions/{id}": {},
+            "/me/profile/projects": {},
+            "/me/profile/projects/{id}": {},
+            "/me/profile/publications": {},
+            "/me/profile/publications/{id}": {},
+            "/me/profile/skills": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/skills/{id}": {},
+            "/me/profile/webaccounts": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/webaccounts/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/websites": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/websites/{id}": {},
+            "/me/responsibilities": {},
+            "/users/{id}/outlook/supportedlanguages": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/outlook/supportedtimezones": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/outlook/supportedtimezones(timezonestandard={value})": {},
+            "/users/{id}/profile": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/account": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/account/{id}": {},
+            "/users/{id}/profile/addresses": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/addresses/{id}": {},
+            "/users/{id}/profile/anniversaries": {},
+            "/users/{id}/profile/anniversaries/{id}": {},
+            "/users/{id}/profile/awards": {},
+            "/users/{id}/profile/awards/{id}": {},
+            "/users/{id}/profile/certifications": {},
+            "/users/{id}/profile/certifications/{id}": {},
+            "/users/{id}/profile/educationalactivities": {},
+            "/users/{id}/profile/educationalactivities/{id}": {},
+            "/users/{id}/profile/emails": {},
+            "/users/{id}/profile/emails/{id}": {},
+            "/users/{id}/profile/interests": {},
+            "/users/{id}/profile/interests/{id}": {},
+            "/users/{id}/profile/languages": {},
+            "/users/{id}/profile/languages/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/names/{id}": {},
+            "/users/{id}/profile/notes": {},
+            "/users/{id}/profile/patents": {},
+            "/users/{id}/profile/patents/{id}": {},
+            "/users/{id}/profile/phones": {},
+            "/users/{id}/profile/phones/{id}": {},
+            "/users/{id}/profile/positions": {},
+            "/users/{id}/profile/positions/{id}": {},
+            "/users/{id}/profile/projects": {},
+            "/users/{id}/profile/projects/{id}": {},
+            "/users/{id}/profile/publications": {},
+            "/users/{id}/profile/publications/{id}": {},
+            "/users/{id}/profile/skills": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/skills/{id}": {},
+            "/users/{id}/profile/webaccounts": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/webaccounts/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/websites": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/websites/{id}": {},
+            "/users/{id}/responsibilities": {}
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/{id}/transitivereports/$count": {},
+            "/settings/regionalandlanguagesettings": {}
+          }
+        },
+        {
+          "methods": [
+            "DELETE",
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/notes/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/responsibilities/{id}": {},
+            "/users/{id}/profile/notes/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/responsibilities/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/names": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/names": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/translateexchangeids": {},
+            "/users/{id}/translateexchangeids": {}
+          }
+        }
+      ],
+      "ownerEmail": ""
+    },
+    "User.Read.All": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Read all users\u0027 full profiles",
+          "adminDescription": "Allows the app to read the full set of profile properties, reports, and managers of other users in your organization, on behalf of the signed-in user.",
+          "userDisplayName": "Read all users\u0027 full profiles",
+          "userDescription": "Allows the app to read the full set of profile properties, reports, and managers of other users in your organization, on your behalf.",
+          "requiresAdminConsent": true
+        },
+        "Application": {
+          "adminDisplayName": "Read all users\u0027 full profiles",
+          "adminDescription": "Allows the app to read user profiles without a signed in user.",
+          "requiresAdminConsent": true
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/directory/deleteditems/microsoft.graph.application": {},
+            "/directory/deleteditems/microsoft.graph.group": {},
+            "/directory/deleteditems/microsoft.graph.serviceprincipal": {},
+            "/directory/deleteditems/microsoft.graph.user": {},
+            "/directory/deleteditems/{id}": {},
+            "/me": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/createdobjects": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/directreports": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/me/joinedteams": {},
+            "/me/licensedetails": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/manager": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/me/ownedobjects": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/registereddevices": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users": {},
+            "/users/delta": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}": {},
+            "/users/{id}/createdobjects": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/directreports": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/joinedteams": {},
+            "/users/{id}/licensedetails": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/manager": {},
+            "/users/{id}/owneddevices": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/ownedobjects": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/registereddevices": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/transitivereports/$count": {},
+            "/users/{id}/usagerights": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/datapolicyoperations/{id}": {},
+            "/settings/regionalandlanguagesettings": {},
+            "/me/findroomlists": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/findrooms": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/findrooms(roomlist={value})": {},
+            "/me/settings": {},
+            "/users/{id}/findroomlists": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/findrooms": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/findrooms(roomlist={value})": {},
+            "/users/{id}/settings": {}
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/contacts/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/contacts/{id}/checkmemberobjects": {},
+            "/contacts/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/contacts/{id}/getmemberobjects": {},
+            "/devices/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/devices/{id}/checkmemberobjects": {},
+            "/devices/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/devices/{id}/getmemberobjects": {},
+            "/directoryobjects/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/directoryobjects/{id}/checkmemberobjects": {},
+            "/directoryobjects/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/directoryobjects/{id}/getmemberobjects": {},
+            "/groups/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/groups/{id}/checkmemberobjects": {},
+            "/groups/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/groups/{id}/getmemberobjects": {},
+            "/me/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/checkmemberobjects": {},
+            "/me/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/getmemberobjects": {},
+            "/serviceprincipals/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/serviceprincipals/{id}/checkmemberobjects": {},
+            "/serviceprincipals/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/serviceprincipals/{id}/getmemberobjects": {},
+            "/users/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/checkmemberobjects": {},
+            "/users/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/getmemberobjects": {},
+            "/me/translateexchangeids": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/translateexchangeids": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/organization/{id}/branding": {},
+            "/organization/{id}/branding/localizations/{id}": {},
+            "/organization/{id}/branding/localizations": {},
+            "/organization/{id}/settings/iteminsights": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/organization/{id}/settings/peopleinsights": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/settings/shiftpreferences": {}
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/groups/evaluatedynamicmembership": {},
+            "/groups/{id}/evaluatedynamicmembership": {}
+          }
+        },
+        {
+          "methods": [
+            "DELETE",
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/notes/{id}": {},
+            "/me/responsibilities/{id}": {},
+            "/users/{id}/profile/notes/{id}": {},
+            "/users/{id}/responsibilities/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "Application"
+          ],
+          "paths": {
+            "/me/memberof/{id}": {},
+            "/me/outlook/supportedlanguages": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/outlook/supportedtimezones": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/outlook/supportedtimezones(timezonestandard={value})": {},
+            "/users/{id}/accountenabled": {},
+            "/users/{id}/agegroup": {},
+            "/users/{id}/assignedlicenses": {},
+            "/users/{id}/assignedplans": {},
+            "/users/{id}/businessphones": {},
+            "/users/{id}/city": {},
+            "/users/{id}/companyname": {},
+            "/users/{id}/consentprovidedforminor": {},
+            "/users/{id}/country": {},
+            "/users/{id}/createddatetime": {},
+            "/users/{id}/creationtype": {},
+            "/users/{id}/deleteddatetime": {},
+            "/users/{id}/department": {},
+            "/users/{id}/devicekeys": {},
+            "/users/{id}/displayname": {},
+            "/users/{id}/employeeid": {},
+            "/users/{id}/externaluserstate": {},
+            "/users/{id}/externaluserstatechangedatetime": {},
+            "/users/{id}/faxnumber": {},
+            "/users/{id}/givenname": {},
+            "/users/{id}/id": {},
+            "/users/{id}/identities": {},
+            "/users/{id}/imaddresses": {},
+            "/users/{id}/isresourceaccount": {},
+            "/users/{id}/jobtitle": {},
+            "/users/{id}/legalagegroupclassification": {},
+            "/users/{id}/mail": {},
+            "/users/{id}/mailnickname": {},
+            "/users/{id}/memberof/{id}": {},
+            "/users/{id}/mobilephone": {},
+            "/users/{id}/officelocation": {},
+            "/users/{id}/onpremisesdistinguishedname": {},
+            "/users/{id}/onpremisesdomainname": {},
+            "/users/{id}/onpremisesextensionattributes": {},
+            "/users/{id}/onpremisesimmutableid": {},
+            "/users/{id}/onpremiseslastsyncdatetime": {},
+            "/users/{id}/onpremisesprovisioningerrors": {},
+            "/users/{id}/onpremisessamaccountname": {},
+            "/users/{id}/onpremisessecurityidentifier": {},
+            "/users/{id}/onpremisessyncenabled": {},
+            "/users/{id}/onpremisesuserprincipalname": {},
+            "/users/{id}/othermails": {},
+            "/users/{id}/outlook/supportedlanguages": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/outlook/supportedtimezones": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/outlook/supportedtimezones(timezonestandard={value})": {},
+            "/users/{id}/passwordpolicies": {},
+            "/users/{id}/passwordprofile": {},
+            "/users/{id}/photo": {},
+            "/users/{id}/photos": {},
+            "/users/{id}/photos/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/postalcode": {},
+            "/users/{id}/preferreddatalocation": {},
+            "/users/{id}/provisionedplans": {},
+            "/users/{id}/proxyaddresses": {},
+            "/users/{id}/refreshtokensvalidfromdatetime": {},
+            "/users/{id}/showinaddresslist": {},
+            "/users/{id}/signinsessionsvalidfromdatetime": {},
+            "/users/{id}/state": {},
+            "/users/{id}/streetaddress": {},
+            "/users/{id}/surname": {},
+            "/users/{id}/usagelocation": {},
+            "/users/{id}/userprincipalname": {},
+            "/users/{id}/usertype": {}
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile": {},
+            "/me/profile/account": {},
+            "/me/profile/account/{id}": {},
+            "/me/profile/addresses": {},
+            "/me/profile/addresses/{id}": {},
+            "/me/profile/anniversaries": {},
+            "/me/profile/anniversaries/{id}": {},
+            "/me/profile/awards": {},
+            "/me/profile/awards/{id}": {},
+            "/me/profile/certifications": {},
+            "/me/profile/certifications/{id}": {},
+            "/me/profile/educationalactivities": {},
+            "/me/profile/educationalactivities/{id}": {},
+            "/me/profile/emails": {},
+            "/me/profile/emails/{id}": {},
+            "/me/profile/interests": {},
+            "/me/profile/interests/{id}": {},
+            "/me/profile/languages": {},
+            "/me/profile/languages/{id}": {},
+            "/me/profile/names/{id}": {},
+            "/me/profile/notes": {},
+            "/me/profile/patents": {},
+            "/me/profile/patents/{id}": {},
+            "/me/profile/phones": {},
+            "/me/profile/phones/{id}": {},
+            "/me/profile/positions": {},
+            "/me/profile/positions/{id}": {},
+            "/me/profile/projects": {},
+            "/me/profile/projects/{id}": {},
+            "/me/profile/publications": {},
+            "/me/profile/publications/{id}": {},
+            "/me/profile/skills": {},
+            "/me/profile/skills/{id}": {},
+            "/me/profile/webaccounts": {},
+            "/me/profile/webaccounts/{id}": {},
+            "/me/profile/websites": {},
+            "/me/profile/websites/{id}": {},
+            "/me/responsibilities": {},
+            "/users/{id}/profile": {},
+            "/users/{id}/profile/account": {},
+            "/users/{id}/profile/account/{id}": {},
+            "/users/{id}/profile/addresses": {},
+            "/users/{id}/profile/addresses/{id}": {},
+            "/users/{id}/profile/anniversaries": {},
+            "/users/{id}/profile/anniversaries/{id}": {},
+            "/users/{id}/profile/awards": {},
+            "/users/{id}/profile/awards/{id}": {},
+            "/users/{id}/profile/certifications": {},
+            "/users/{id}/profile/certifications/{id}": {},
+            "/users/{id}/profile/educationalactivities": {},
+            "/users/{id}/profile/educationalactivities/{id}": {},
+            "/users/{id}/profile/emails": {},
+            "/users/{id}/profile/emails/{id}": {},
+            "/users/{id}/profile/interests": {},
+            "/users/{id}/profile/interests/{id}": {},
+            "/users/{id}/profile/languages": {},
+            "/users/{id}/profile/languages/{id}": {},
+            "/users/{id}/profile/names/{id}": {},
+            "/users/{id}/profile/notes": {},
+            "/users/{id}/profile/patents": {},
+            "/users/{id}/profile/patents/{id}": {},
+            "/users/{id}/profile/phones": {},
+            "/users/{id}/profile/phones/{id}": {},
+            "/users/{id}/profile/positions": {},
+            "/users/{id}/profile/positions/{id}": {},
+            "/users/{id}/profile/projects": {},
+            "/users/{id}/profile/projects/{id}": {},
+            "/users/{id}/profile/publications": {},
+            "/users/{id}/profile/publications/{id}": {},
+            "/users/{id}/profile/skills": {},
+            "/users/{id}/profile/skills/{id}": {},
+            "/users/{id}/profile/webaccounts": {},
+            "/users/{id}/profile/webaccounts/{id}": {},
+            "/users/{id}/profile/websites": {},
+            "/users/{id}/profile/websites/{id}": {},
+            "/users/{id}/responsibilities": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/names": {},
+            "/users/{id}/profile/names": {}
+          }
+        }
+      ],
+      "ownerEmail": ""
+    },
+    "User.ReadBasic.All": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Read all users\u0027 basic profiles",
+          "adminDescription": "Allows the app to read a basic set of profile properties of other users in your organization on behalf of the signed-in user. This includes display name, first and last name, email address and photo.",
+          "userDisplayName": "Read all users\u0027 basic profiles",
+          "userDescription": "Allows the app to read a basic set of profile properties of other users in your organization on your behalf. Includes display name, first and last name, email address and photo.",
+          "requiresAdminConsent": false
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/{id}/approleassignments": {},
+            "/me/oauth2permissiongrants": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/oauth2permissiongrants": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me": {},
+            "/users": {},
+            "/users/delta": {},
+            "/users/{id}": {},
+            "/organization/{id}/branding": {},
+            "/organization/{id}/branding/localizations/{id}": {},
+            "/organization/{id}/branding/localizations": {},
+            "/me/findroomlists": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/findrooms": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/findrooms(roomlist={value})": {},
+            "/me/outlook/supportedlanguages": {},
+            "/me/outlook/supportedtimezones": {},
+            "/me/outlook/supportedtimezones(timezonestandard={value})": {},
+            "/users/{id}/displayname": {},
+            "/users/{id}/findroomlists": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/findrooms": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/findrooms(roomlist={value})": {},
+            "/users/{id}/givenname": {},
+            "/users/{id}/id": {},
+            "/users/{id}/identities": {},
+            "/users/{id}/mail": {},
+            "/users/{id}/outlook/supportedlanguages": {},
+            "/users/{id}/outlook/supportedtimezones": {},
+            "/users/{id}/outlook/supportedtimezones(timezonestandard={value})": {},
+            "/users/{id}/surname": {},
+            "/users/{id}/userprincipalname": {},
+            "/me/accountenabled": {},
+            "/me/agegroup": {},
+            "/me/assignedlicenses": {},
+            "/me/assignedplans": {},
+            "/me/businessphones": {},
+            "/me/city": {},
+            "/me/companyname": {},
+            "/me/consentprovidedforminor": {},
+            "/me/country": {},
+            "/me/createddatetime": {},
+            "/me/creationtype": {},
+            "/me/deleteddatetime": {},
+            "/me/department": {},
+            "/me/devicekeys": {},
+            "/me/displayname": {},
+            "/me/employeeid": {},
+            "/me/externaluserstate": {},
+            "/me/externaluserstatechangedatetime": {},
+            "/me/faxnumber": {},
+            "/me/givenname": {},
+            "/me/id": {},
+            "/me/identities": {},
+            "/me/imaddresses": {},
+            "/me/isresourceaccount": {},
+            "/me/jobtitle": {},
+            "/me/legalagegroupclassification": {},
+            "/me/mail": {},
+            "/me/mailnickname": {},
+            "/me/mobilephone": {},
+            "/me/officelocation": {},
+            "/me/onpremisesdistinguishedname": {},
+            "/me/onpremisesdomainname": {},
+            "/me/onpremisesextensionattributes": {},
+            "/me/onpremisesimmutableid": {},
+            "/me/onpremiseslastsyncdatetime": {},
+            "/me/onpremisesprovisioningerrors": {},
+            "/me/onpremisessamaccountname": {},
+            "/me/onpremisessecurityidentifier": {},
+            "/me/onpremisessyncenabled": {},
+            "/me/onpremisesuserprincipalname": {},
+            "/me/othermails": {},
+            "/me/passwordpolicies": {},
+            "/me/passwordprofile": {},
+            "/me/postalcode": {},
+            "/me/preferreddatalocation": {},
+            "/me/provisionedplans": {},
+            "/me/proxyaddresses": {},
+            "/me/refreshtokensvalidfromdatetime": {},
+            "/me/showinaddresslist": {},
+            "/me/signinsessionsvalidfromdatetime": {},
+            "/me/state": {},
+            "/me/streetaddress": {},
+            "/me/surname": {},
+            "/me/usagelocation": {},
+            "/me/userprincipalname": {},
+            "/me/usertype": {}
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/contacts/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/contacts/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/devices/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/devices/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/directoryobjects/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/directoryobjects/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/groups/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/groups/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE",
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/notes/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/responsibilities/{id}": {},
+            "/users/{id}/profile/notes/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/responsibilities/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/account": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/account/{id}": {},
+            "/me/profile/addresses": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/addresses/{id}": {},
+            "/me/profile/anniversaries": {},
+            "/me/profile/anniversaries/{id}": {},
+            "/me/profile/awards": {},
+            "/me/profile/awards/{id}": {},
+            "/me/profile/certifications": {},
+            "/me/profile/certifications/{id}": {},
+            "/me/profile/educationalactivities": {},
+            "/me/profile/educationalactivities/{id}": {},
+            "/me/profile/emails": {},
+            "/me/profile/emails/{id}": {},
+            "/me/profile/interests": {},
+            "/me/profile/interests/{id}": {},
+            "/me/profile/languages": {},
+            "/me/profile/languages/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/names/{id}": {},
+            "/me/profile/notes": {},
+            "/me/profile/patents": {},
+            "/me/profile/patents/{id}": {},
+            "/me/profile/phones": {},
+            "/me/profile/phones/{id}": {},
+            "/me/profile/positions": {},
+            "/me/profile/positions/{id}": {},
+            "/me/profile/projects": {},
+            "/me/profile/projects/{id}": {},
+            "/me/profile/publications": {},
+            "/me/profile/publications/{id}": {},
+            "/me/profile/skills": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/skills/{id}": {},
+            "/me/profile/webaccounts": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/webaccounts/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/websites": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/websites/{id}": {},
+            "/me/responsibilities": {},
+            "/users/{id}/profile": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/account": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/account/{id}": {},
+            "/users/{id}/profile/addresses": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/addresses/{id}": {},
+            "/users/{id}/profile/anniversaries": {},
+            "/users/{id}/profile/anniversaries/{id}": {},
+            "/users/{id}/profile/awards": {},
+            "/users/{id}/profile/awards/{id}": {},
+            "/users/{id}/profile/certifications": {},
+            "/users/{id}/profile/certifications/{id}": {},
+            "/users/{id}/profile/educationalactivities": {},
+            "/users/{id}/profile/educationalactivities/{id}": {},
+            "/users/{id}/profile/emails": {},
+            "/users/{id}/profile/emails/{id}": {},
+            "/users/{id}/profile/interests": {},
+            "/users/{id}/profile/interests/{id}": {},
+            "/users/{id}/profile/languages": {},
+            "/users/{id}/profile/languages/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/names/{id}": {},
+            "/users/{id}/profile/notes": {},
+            "/users/{id}/profile/patents": {},
+            "/users/{id}/profile/patents/{id}": {},
+            "/users/{id}/profile/phones": {},
+            "/users/{id}/profile/phones/{id}": {},
+            "/users/{id}/profile/positions": {},
+            "/users/{id}/profile/positions/{id}": {},
+            "/users/{id}/profile/projects": {},
+            "/users/{id}/profile/projects/{id}": {},
+            "/users/{id}/profile/publications": {},
+            "/users/{id}/profile/publications/{id}": {},
+            "/users/{id}/profile/skills": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/skills/{id}": {},
+            "/users/{id}/profile/webaccounts": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/webaccounts/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/websites": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/websites/{id}": {},
+            "/users/{id}/responsibilities": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/names": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/names": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/translateexchangeids": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/translateexchangeids": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            }
+          }
+        }
+      ],
+      "ownerEmail": ""
+    },
+    "User.ReadWrite": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Read and write access to user profile",
+          "adminDescription": "Allows the app to read your profile. It also allows the app to update your profile information on your behalf.",
+          "userDisplayName": "Read and update your profile",
+          "userDescription": "Allows the app to read your profile, and discover your group membership, reports and manager. It also allows the app to update your profile information on your behalf.",
+          "requiresAdminConsent": false
+        },
+        "DelegatedPersonal": {
+          "adminDisplayName": "Read and write access to user profile",
+          "adminDescription": "Allows the app to read your profile. It also allows the app to update your profile information on your behalf.",
+          "userDisplayName": "Read and update your profile",
+          "userDescription": "Allows the app to read your profile, and discover your group membership, reports and manager. It also allows the app to update your profile information on your behalf.",
+          "requiresAdminConsent": false
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me": {},
+            "/me/createdobjects": {},
+            "/users/{id}/createdobjects": {}
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/delta": {},
+            "/users/{id}/usagerights": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/users/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/me/settings/contactmergesuggestions": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/settings/iteminsights": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/settings/contactmergesuggestions": {},
+            "/users/{id}/settings/iteminsights": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/me/invalidateallrefreshtokens": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/validatepassword": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/invalidateallrefreshtokens": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "PATCH",
+            "PUT"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/settings/regionalandlanguagesettings": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE",
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/notes/{id}": {},
+            "/me/responsibilities/{id}": {},
+            "/users/{id}/profile/notes/{id}": {},
+            "/users/{id}/responsibilities/{id}": {},
+            "/me/profile/account/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/addresses/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/anniversaries/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/awards/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/certifications/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/educationalactivities/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/emails/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/interests/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/languages/{id}": {},
+            "/me/profile/names/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/patents/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/phones/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/positions/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/projects/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/publications/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/skills/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/webaccounts/{id}": {},
+            "/me/profile/websites/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/account/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/addresses/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/anniversaries/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/awards/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/certifications/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/educationalactivities/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/emails/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/interests/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/languages/{id}": {},
+            "/users/{id}/profile/names/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/patents/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/phones/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/positions/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/projects/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/publications/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/skills/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/webaccounts/{id}": {},
+            "/users/{id}/profile/websites/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "DELETE"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile": {},
+            "/users/{id}/profile": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/account": {},
+            "/me/profile/addresses": {},
+            "/me/profile/anniversaries": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/awards": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/certifications": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/educationalactivities": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/emails": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/interests": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/languages": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/names": {},
+            "/me/profile/notes": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/patents": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/phones": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/positions": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/projects": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/publications": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/skills": {},
+            "/me/profile/webaccounts": {},
+            "/me/profile/websites": {},
+            "/me/responsibilities": {},
+            "/users/{id}/profile/account": {},
+            "/users/{id}/profile/addresses": {},
+            "/users/{id}/profile/anniversaries": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/awards": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/certifications": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/educationalactivities": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/emails": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/interests": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/languages": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/names": {},
+            "/users/{id}/profile/notes": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/patents": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/phones": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/positions": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/projects": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/publications": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/skills": {},
+            "/users/{id}/profile/webaccounts": {},
+            "/users/{id}/profile/websites": {},
+            "/users/{id}/responsibilities": {}
+          }
+        },
+        {
+          "methods": [
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/me/settings": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/settings": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "PATCH",
+            "PUT"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/{id}/photo": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/photo": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/translateexchangeids": {},
+            "/users/{id}/translateexchangeids": {}
+          }
+        }
+      ],
+      "ownerEmail": ""
+    },
+    "User.ReadWrite.All": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Read and write all users\u0027 full profiles",
+          "adminDescription": "Allows the app to read and write the full set of profile properties, reports, and managers of other users in your organization, on behalf of the signed-in user.",
+          "userDisplayName": "Read and write all users\u0027 full profiles",
+          "userDescription": "Allows the app to read and write the full set of profile properties, reports, and managers of other users in your organization, on your behalf.",
+          "requiresAdminConsent": true
+        },
+        "Application": {
+          "adminDisplayName": "Read and write all users\u0027 full profiles",
+          "adminDescription": "Allows the app to read and update user profiles without a signed in user.",
+          "requiresAdminConsent": true
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/directory/deleteditems/microsoft.graph.application": {},
+            "/directory/deleteditems/microsoft.graph.group": {},
+            "/directory/deleteditems/microsoft.graph.serviceprincipal": {},
+            "/directory/deleteditems/microsoft.graph.user": {},
+            "/me": {},
+            "/me/createdobjects": {},
+            "/me/directreports": {},
+            "/me/joinedteams": {},
+            "/me/licensedetails": {},
+            "/me/manager": {},
+            "/me/ownedobjects": {},
+            "/me/registereddevices": {},
+            "/users/delta": {},
+            "/users/{id}/createdobjects": {},
+            "/users/{id}/directreports": {},
+            "/users/{id}/joinedteams": {},
+            "/users/{id}/licensedetails": {},
+            "/users/{id}/owneddevices": {},
+            "/users/{id}/ownedobjects": {},
+            "/users/{id}/registereddevices": {},
+            "/users/{id}/usagerights": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "DELETE"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/directory/deleteditems/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/contacts/{id}/checkmembergroups": {},
+            "/contacts/{id}/checkmemberobjects": {},
+            "/contacts/{id}/getmemberobjects": {},
+            "/devices/{id}/checkmembergroups": {},
+            "/devices/{id}/checkmemberobjects": {},
+            "/devices/{id}/getmemberobjects": {},
+            "/directoryobjects/{id}/checkmembergroups": {},
+            "/directoryobjects/{id}/checkmemberobjects": {},
+            "/directoryobjects/{id}/getmemberobjects": {},
+            "/groups/{id}/checkmembergroups": {},
+            "/groups/{id}/checkmemberobjects": {},
+            "/groups/{id}/getmemberobjects": {},
+            "/me/checkmembergroups": {},
+            "/me/checkmemberobjects": {},
+            "/me/getmemberobjects": {},
+            "/serviceprincipals/{id}/checkmembergroups": {},
+            "/serviceprincipals/{id}/checkmemberobjects": {},
+            "/serviceprincipals/{id}/getmemberobjects": {},
+            "/users/{id}/checkmembergroups": {},
+            "/users/{id}/checkmemberobjects": {},
+            "/users/{id}/getmemberobjects": {},
+            "/directory/deleteditems/{id}/restore": {},
+            "/invitations": {},
+            "/me/revokesigninsessions": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/assignlicense": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/reprocesslicenseassignment": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/revokesigninsessions": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/me/translateexchangeids": {},
+            "/users/{id}/translateexchangeids": {}
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/directoryobjects/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "PATCH",
+            "DELETE"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "PUT"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/{id}/manager": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/organization/{id}/settings/iteminsights": {},
+            "/organization/{id}/settings/peopleinsights": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "PUT"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/{id}/settings/shiftpreferences": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/validatepassword": {}
+          }
+        },
+        {
+          "methods": [
+            "PATCH",
+            "PUT"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/settings/regionalandlanguagesettings": {}
+          }
+        },
+        {
+          "methods": [
+            "DELETE",
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/notes/{id}": {},
+            "/me/responsibilities/{id}": {},
+            "/users/{id}/profile/notes/{id}": {},
+            "/users/{id}/responsibilities/{id}": {},
+            "/me/profile/account/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/addresses/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/anniversaries/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/awards/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/certifications/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/educationalactivities/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/emails/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/interests/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/languages/{id}": {},
+            "/me/profile/names/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/patents/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/phones/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/positions/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/projects/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/publications/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/skills/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/webaccounts/{id}": {},
+            "/me/profile/websites/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/account/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/addresses/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/anniversaries/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/awards/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/certifications/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/educationalactivities/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/emails/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/interests/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/languages/{id}": {},
+            "/users/{id}/profile/names/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/patents/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/phones/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/positions/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/projects/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/publications/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/skills/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/webaccounts/{id}": {},
+            "/users/{id}/profile/websites/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "DELETE"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile": {},
+            "/users/{id}/profile": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/account": {},
+            "/me/profile/addresses": {},
+            "/me/profile/anniversaries": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/awards": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/certifications": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/educationalactivities": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/emails": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/interests": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/languages": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/names": {},
+            "/me/profile/notes": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/patents": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/phones": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/positions": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/projects": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/publications": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/skills": {},
+            "/me/profile/webaccounts": {},
+            "/me/profile/websites": {},
+            "/me/responsibilities": {},
+            "/users/{id}/profile/account": {},
+            "/users/{id}/profile/addresses": {},
+            "/users/{id}/profile/anniversaries": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/awards": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/certifications": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/educationalactivities": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/emails": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/interests": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/languages": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/names": {},
+            "/users/{id}/profile/notes": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/patents": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/phones": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/positions": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/projects": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/publications": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/skills": {},
+            "/users/{id}/profile/webaccounts": {},
+            "/users/{id}/profile/websites": {},
+            "/users/{id}/responsibilities": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/me/settings": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/settings": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "PATCH",
+            "PUT"
+          ],
+          "schemeKeys": [
+            "Application"
+          ],
+          "paths": {
+            "/users/{id}/photo": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            }
+          }
+        }
+      ],
+      "ownerEmail": ""
+    }
+  }
+}

--- a/kibaliTests/InvalidUser.json
+++ b/kibaliTests/InvalidUser.json
@@ -1,0 +1,2795 @@
+{
+  "$schema": "https://microsoftgraph.github.io/msgraph-metadata/graph-permissions-schema.json",
+  "permissions": {
+    "User.Export.All": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Export user\u0027s data",
+          "adminDescription": "Allows the app to export data (e.g. customer content or system-generated logs), associated with any user in your company, when the app is used by a privileged user (e.g. a Company Administrator).",
+          "userDisplayName": "Export user\u0027s data",
+          "userDescription": "Allows the app to export data (e.g. customer content or system-generated logs), associated with any user in your company, when the app is used by a privileged user (e.g. a Company Administrator).",
+          "requiresAdminConsent": true
+        },
+        "Application": {
+          "adminDisplayName": "Export user\u0027s data",
+          "adminDescription": "Allows the app to export data (e.g. customer content or system-generated logs), associated with any user in your company, when the app is used by a privileged user (e.g. a Company Administrator).",
+          "requiresAdminConsent": true
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/datapolicyoperations/{id}": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/{id}/exportpersonaldata": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            }
+          }
+        }
+      ],
+      "ownerEmail": ""
+    },
+    "User.Invite.All": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Invite guest users to the organization",
+          "adminDescription": "Allows the app to invite guest users to the organization, on behalf of the signed-in user.",
+          "userDisplayName": "Invite guest users to the organization",
+          "userDescription": "Allows the app to invite guest users to the organization, on your behalf.",
+          "requiresAdminConsent": true
+        },
+        "Application": {
+          "adminDisplayName": "Invite guest users to the organization",
+          "adminDescription": "Allows the app to invite guest users to the organization, without a signed-in user.",
+          "requiresAdminConsent": true
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/invitations": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            }
+          }
+        }
+      ],
+      "ownerEmail": ""
+    },
+    "User.ManageIdentities.All": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Manage  user identities",
+          "adminDescription": "Allows the app to read, update and delete identities that are associated with a user\u0027s account that the signed-in user has access to. This controls the identities users can sign-in with.",
+          "userDisplayName": "Manage  user identities",
+          "userDescription": "Allows the app to read, update and delete identities that are associated with a user\u0027s account that you have access to. This controls the identities users can sign-in with.",
+          "requiresAdminConsent": true
+        },
+        "Application": {
+          "adminDisplayName": "Manage all users\u0027 identities",
+          "adminDescription": "Allows the app to read, update and delete identities that are associated with a user\u0027s account, without a signed in user. This controls the identities users can sign-in with.",
+          "requiresAdminConsent": true
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/{id}": {}
+          }
+        }
+      ],
+      "ownerEmail": ""
+    },
+    "User.Read": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Sign in and read user profile",
+          "adminDescription": "Allows users to sign-in to the app, and allows the app to read the profile of signed-in users. It also allows the app to read basic company information of signed-in users.",
+          "userDisplayName": "Sign you in and read your profile",
+          "userDescription": "Allows you to sign in to the app with your organizational account and let the app read your profile. It also allows the app to read basic company information.",
+          "requiresAdminConsent": false
+        },
+        "DelegatedPersonal": {
+          "adminDisplayName": "Sign in and read user profile",
+          "adminDescription": "Allows users to sign-in to the app, and allows the app to read the profile of signed-in users. It also allows the app to read basic company information of signed-in users.",
+          "userDisplayName": "Sign you in and read your profile",
+          "userDescription": "Allows you to sign in to the app with your organizational account and let the app read your profile. It also allows the app to read basic company information.",
+          "requiresAdminConsent": false
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/applications": {}
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/schemaextensions": {},
+            "/schemaextensions/{id}": {},
+            "/organization": {},
+            "/education/me/user": {},
+            "/education/users/{id}/user": {},
+            "/me/directreports": {},
+            "/me/memberof": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/ownedobjects": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/registereddevices": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/delta": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/memberof": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/ownedobjects": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/registereddevices": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/transitivememberof": {},
+            "/users/{id}/usagerights": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/drive": {},
+            "/me/drives": {},
+            "/organization/{id}/branding": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/organization/{id}/branding/localizations/{id}": {},
+            "/me/analytics/settings": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/settings/contactmergesuggestions": {},
+            "/me/settings/iteminsights": {},
+            "/organization/{id}/branding/localizations": {},
+            "/users/{id}/analytics/settings": {},
+            "/users/{id}/settings/contactmergesuggestions": {},
+            "/users/{id}/settings/iteminsights": {},
+            "/me/findmeetingtimes": {},
+            "/me/findroomlists": {},
+            "/me/findrooms": {},
+            "/me/memberof/{id}": {},
+            "/me/settings": {},
+            "/users/{id}/accountenabled": {},
+            "/users/{id}/agegroup": {},
+            "/users/{id}/assignedlicenses": {},
+            "/users/{id}/assignedplans": {},
+            "/users/{id}/businessphones": {},
+            "/users/{id}/city": {},
+            "/users/{id}/companyname": {},
+            "/users/{id}/consentprovidedforminor": {},
+            "/users/{id}/country": {},
+            "/users/{id}/createddatetime": {},
+            "/users/{id}/creationtype": {},
+            "/users/{id}/deleteddatetime": {},
+            "/users/{id}/department": {},
+            "/users/{id}/devicekeys": {},
+            "/users/{id}/employeeid": {},
+            "/users/{id}/externaluserstate": {},
+            "/users/{id}/externaluserstatechangedatetime": {},
+            "/users/{id}/faxnumber": {},
+            "/users/{id}/imaddresses": {},
+            "/users/{id}/isresourceaccount": {},
+            "/users/{id}/jobtitle": {},
+            "/users/{id}/legalagegroupclassification": {},
+            "/users/{id}/mailnickname": {},
+            "/users/{id}/memberof/{id}": {},
+            "/users/{id}/mobilephone": {},
+            "/users/{id}/officelocation": {},
+            "/users/{id}/onpremisesdistinguishedname": {},
+            "/users/{id}/onpremisesdomainname": {},
+            "/users/{id}/onpremisesextensionattributes": {},
+            "/users/{id}/onpremisesimmutableid": {},
+            "/users/{id}/onpremiseslastsyncdatetime": {},
+            "/users/{id}/onpremisesprovisioningerrors": {},
+            "/users/{id}/onpremisessamaccountname": {},
+            "/users/{id}/onpremisessecurityidentifier": {},
+            "/users/{id}/onpremisessyncenabled": {},
+            "/users/{id}/onpremisesuserprincipalname": {},
+            "/users/{id}/othermails": {},
+            "/users/{id}/passwordpolicies": {},
+            "/users/{id}/passwordprofile": {},
+            "/users/{id}/photo": {},
+            "/users/{id}/photos": {},
+            "/users/{id}/photos/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/postalcode": {},
+            "/users/{id}/preferreddatalocation": {},
+            "/users/{id}/provisionedplans": {},
+            "/users/{id}/proxyaddresses": {},
+            "/users/{id}/refreshtokensvalidfromdatetime": {},
+            "/users/{id}/showinaddresslist": {},
+            "/users/{id}/signinsessionsvalidfromdatetime": {},
+            "/users/{id}/state": {},
+            "/users/{id}/streetaddress": {},
+            "/users/{id}/usagelocation": {},
+            "/users/{id}/usertype": {},
+            "/me/exportpersonaldata": {},
+            "/me/extensions": {},
+            "/me/onenote": {},
+            "/me/outlook": {},
+            "/me/owneddevices": {},
+            "/me/photo": {},
+            "/me/photos": {},
+            "/me/photos/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/contacts/{id}/checkmemberobjects": {},
+            "/contacts/{id}/getmemberobjects": {},
+            "/devices/{id}/checkmemberobjects": {},
+            "/devices/{id}/getmemberobjects": {},
+            "/directoryobjects/{id}/checkmemberobjects": {},
+            "/directoryobjects/{id}/getmemberobjects": {},
+            "/groups/{id}/checkmemberobjects": {},
+            "/groups/{id}/getmemberobjects": {},
+            "/me/checkmemberobjects": {},
+            "/me/getmemberobjects": {},
+            "/serviceprincipals/{id}/checkmemberobjects": {},
+            "/serviceprincipals/{id}/getmemberobjects": {},
+            "/users/{id}/checkmemberobjects": {},
+            "/users/{id}/getmemberobjects": {}
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/createdobjects": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/licensedetails": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}": {},
+            "/users/{id}/createdobjects": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/licensedetails": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/outlook/supportedlanguages": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/outlook/supportedtimezones": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/outlook/supportedtimezones(timezonestandard={value})": {},
+            "/me/profile": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/account": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/account/{id}": {},
+            "/me/profile/addresses": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/addresses/{id}": {},
+            "/me/profile/anniversaries": {},
+            "/me/profile/anniversaries/{id}": {},
+            "/me/profile/awards": {},
+            "/me/profile/awards/{id}": {},
+            "/me/profile/certifications": {},
+            "/me/profile/certifications/{id}": {},
+            "/me/profile/educationalactivities": {},
+            "/me/profile/educationalactivities/{id}": {},
+            "/me/profile/emails": {},
+            "/me/profile/emails/{id}": {},
+            "/me/profile/interests": {},
+            "/me/profile/interests/{id}": {},
+            "/me/profile/languages": {},
+            "/me/profile/languages/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/names/{id}": {},
+            "/me/profile/notes": {},
+            "/me/profile/patents": {},
+            "/me/profile/patents/{id}": {},
+            "/me/profile/phones": {},
+            "/me/profile/phones/{id}": {},
+            "/me/profile/positions": {},
+            "/me/profile/positions/{id}": {},
+            "/me/profile/projects": {},
+            "/me/profile/projects/{id}": {},
+            "/me/profile/publications": {},
+            "/me/profile/publications/{id}": {},
+            "/me/profile/skills": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/skills/{id}": {},
+            "/me/profile/webaccounts": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/webaccounts/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/websites": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/websites/{id}": {},
+            "/me/responsibilities": {},
+            "/users/{id}/outlook/supportedlanguages": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/outlook/supportedtimezones": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/outlook/supportedtimezones(timezonestandard={value})": {},
+            "/users/{id}/profile": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/account": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/account/{id}": {},
+            "/users/{id}/profile/addresses": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/addresses/{id}": {},
+            "/users/{id}/profile/anniversaries": {},
+            "/users/{id}/profile/anniversaries/{id}": {},
+            "/users/{id}/profile/awards": {},
+            "/users/{id}/profile/awards/{id}": {},
+            "/users/{id}/profile/certifications": {},
+            "/users/{id}/profile/certifications/{id}": {},
+            "/users/{id}/profile/educationalactivities": {},
+            "/users/{id}/profile/educationalactivities/{id}": {},
+            "/users/{id}/profile/emails": {},
+            "/users/{id}/profile/emails/{id}": {},
+            "/users/{id}/profile/interests": {},
+            "/users/{id}/profile/interests/{id}": {},
+            "/users/{id}/profile/languages": {},
+            "/users/{id}/profile/languages/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/names/{id}": {},
+            "/users/{id}/profile/notes": {},
+            "/users/{id}/profile/patents": {},
+            "/users/{id}/profile/patents/{id}": {},
+            "/users/{id}/profile/phones": {},
+            "/users/{id}/profile/phones/{id}": {},
+            "/users/{id}/profile/positions": {},
+            "/users/{id}/profile/positions/{id}": {},
+            "/users/{id}/profile/projects": {},
+            "/users/{id}/profile/projects/{id}": {},
+            "/users/{id}/profile/publications": {},
+            "/users/{id}/profile/publications/{id}": {},
+            "/users/{id}/profile/skills": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/skills/{id}": {},
+            "/users/{id}/profile/webaccounts": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/webaccounts/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/websites": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/websites/{id}": {},
+            "/users/{id}/responsibilities": {}
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/{id}/transitivereports/$count": {},
+            "/settings/regionalandlanguagesettings": {}
+          }
+        },
+        {
+          "methods": [
+            "DELETE",
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/notes/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/responsibilities/{id}": {},
+            "/users/{id}/profile/notes/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/responsibilities/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/names": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/names": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/translateexchangeids": {},
+            "/users/{id}/translateexchangeids": {}
+          }
+        }
+      ],
+      "ownerEmail": ""
+    },
+    "User.Read.All": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Read all users\u0027 full profiles",
+          "adminDescription": "Allows the app to read the full set of profile properties, reports, and managers of other users in your organization, on behalf of the signed-in user.",
+          "userDisplayName": "Read all users\u0027 full profiles",
+          "userDescription": "Allows the app to read the full set of profile properties, reports, and managers of other users in your organization, on your behalf.",
+          "requiresAdminConsent": true
+        },
+        "Application": {
+          "adminDisplayName": "Read all users\u0027 full profiles",
+          "adminDescription": "Allows the app to read user profiles without a signed in user.",
+          "requiresAdminConsent": true
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/directory/deleteditems/microsoft.graph.application": {},
+            "/directory/deleteditems/microsoft.graph.group": {},
+            "/directory/deleteditems/microsoft.graph.serviceprincipal": {},
+            "/directory/deleteditems/microsoft.graph.user": {},
+            "/directory/deleteditems/{id}": {},
+            "/me": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/me/createdobjects": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/directreports": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/me/joinedteams": {},
+            "/me/licensedetails": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/manager": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/me/ownedobjects": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/registereddevices": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users": {},
+            "/users/delta": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}": {},
+            "/users/{id}/createdobjects": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/directreports": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/joinedteams": {},
+            "/users/{id}/licensedetails": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/manager": {},
+            "/users/{id}/owneddevices": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/ownedobjects": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/registereddevices": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/transitivereports/$count": {},
+            "/users/{id}/usagerights": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/datapolicyoperations/{id}": {},
+            "/settings/regionalandlanguagesettings": {},
+            "/me/findroomlists": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/findrooms": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/findrooms(roomlist={value})": {},
+            "/me/settings": {},
+            "/users/{id}/findroomlists": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/findrooms": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/findrooms(roomlist={value})": {},
+            "/users/{id}/settings": {}
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/contacts/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/contacts/{id}/checkmemberobjects": {},
+            "/contacts/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/contacts/{id}/getmemberobjects": {},
+            "/devices/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/devices/{id}/checkmemberobjects": {},
+            "/devices/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/devices/{id}/getmemberobjects": {},
+            "/directoryobjects/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/directoryobjects/{id}/checkmemberobjects": {},
+            "/directoryobjects/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/directoryobjects/{id}/getmemberobjects": {},
+            "/groups/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/groups/{id}/checkmemberobjects": {},
+            "/groups/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/groups/{id}/getmemberobjects": {},
+            "/me/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/checkmemberobjects": {},
+            "/me/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/getmemberobjects": {},
+            "/serviceprincipals/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/serviceprincipals/{id}/checkmemberobjects": {},
+            "/serviceprincipals/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/serviceprincipals/{id}/getmemberobjects": {},
+            "/users/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/checkmemberobjects": {},
+            "/users/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/getmemberobjects": {},
+            "/me/translateexchangeids": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/translateexchangeids": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/organization/{id}/branding": {},
+            "/organization/{id}/branding/localizations/{id}": {},
+            "/organization/{id}/branding/localizations": {},
+            "/organization/{id}/settings/iteminsights": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/organization/{id}/settings/peopleinsights": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/settings/shiftpreferences": {}
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/groups/evaluatedynamicmembership": {},
+            "/groups/{id}/evaluatedynamicmembership": {}
+          }
+        },
+        {
+          "methods": [
+            "DELETE",
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/notes/{id}": {},
+            "/me/responsibilities/{id}": {},
+            "/users/{id}/profile/notes/{id}": {},
+            "/users/{id}/responsibilities/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "Application"
+          ],
+          "paths": {
+            "/me/memberof/{id}": {},
+            "/me/outlook/supportedlanguages": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/outlook/supportedtimezones": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/outlook/supportedtimezones(timezonestandard={value})": {},
+            "/users/{id}/accountenabled": {},
+            "/users/{id}/agegroup": {},
+            "/users/{id}/assignedlicenses": {},
+            "/users/{id}/assignedplans": {},
+            "/users/{id}/businessphones": {},
+            "/users/{id}/city": {},
+            "/users/{id}/companyname": {},
+            "/users/{id}/consentprovidedforminor": {},
+            "/users/{id}/country": {},
+            "/users/{id}/createddatetime": {},
+            "/users/{id}/creationtype": {},
+            "/users/{id}/deleteddatetime": {},
+            "/users/{id}/department": {},
+            "/users/{id}/devicekeys": {},
+            "/users/{id}/displayname": {},
+            "/users/{id}/employeeid": {},
+            "/users/{id}/externaluserstate": {},
+            "/users/{id}/externaluserstatechangedatetime": {},
+            "/users/{id}/faxnumber": {},
+            "/users/{id}/givenname": {},
+            "/users/{id}/id": {},
+            "/users/{id}/identities": {},
+            "/users/{id}/imaddresses": {},
+            "/users/{id}/isresourceaccount": {},
+            "/users/{id}/jobtitle": {},
+            "/users/{id}/legalagegroupclassification": {},
+            "/users/{id}/mail": {},
+            "/users/{id}/mailnickname": {},
+            "/users/{id}/memberof/{id}": {},
+            "/users/{id}/mobilephone": {},
+            "/users/{id}/officelocation": {},
+            "/users/{id}/onpremisesdistinguishedname": {},
+            "/users/{id}/onpremisesdomainname": {},
+            "/users/{id}/onpremisesextensionattributes": {},
+            "/users/{id}/onpremisesimmutableid": {},
+            "/users/{id}/onpremiseslastsyncdatetime": {},
+            "/users/{id}/onpremisesprovisioningerrors": {},
+            "/users/{id}/onpremisessamaccountname": {},
+            "/users/{id}/onpremisessecurityidentifier": {},
+            "/users/{id}/onpremisessyncenabled": {},
+            "/users/{id}/onpremisesuserprincipalname": {},
+            "/users/{id}/othermails": {},
+            "/users/{id}/outlook/supportedlanguages": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/outlook/supportedtimezones": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/outlook/supportedtimezones(timezonestandard={value})": {},
+            "/users/{id}/passwordpolicies": {},
+            "/users/{id}/passwordprofile": {},
+            "/users/{id}/photo": {},
+            "/users/{id}/photos": {},
+            "/users/{id}/photos/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/postalcode": {},
+            "/users/{id}/preferreddatalocation": {},
+            "/users/{id}/provisionedplans": {},
+            "/users/{id}/proxyaddresses": {},
+            "/users/{id}/refreshtokensvalidfromdatetime": {},
+            "/users/{id}/showinaddresslist": {},
+            "/users/{id}/signinsessionsvalidfromdatetime": {},
+            "/users/{id}/state": {},
+            "/users/{id}/streetaddress": {},
+            "/users/{id}/surname": {},
+            "/users/{id}/usagelocation": {},
+            "/users/{id}/userprincipalname": {},
+            "/users/{id}/usertype": {}
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile": {},
+            "/me/profile/account": {},
+            "/me/profile/account/{id}": {},
+            "/me/profile/addresses": {},
+            "/me/profile/addresses/{id}": {},
+            "/me/profile/anniversaries": {},
+            "/me/profile/anniversaries/{id}": {},
+            "/me/profile/awards": {},
+            "/me/profile/awards/{id}": {},
+            "/me/profile/certifications": {},
+            "/me/profile/certifications/{id}": {},
+            "/me/profile/educationalactivities": {},
+            "/me/profile/educationalactivities/{id}": {},
+            "/me/profile/emails": {},
+            "/me/profile/emails/{id}": {},
+            "/me/profile/interests": {},
+            "/me/profile/interests/{id}": {},
+            "/me/profile/languages": {},
+            "/me/profile/languages/{id}": {},
+            "/me/profile/names/{id}": {},
+            "/me/profile/notes": {},
+            "/me/profile/patents": {},
+            "/me/profile/patents/{id}": {},
+            "/me/profile/phones": {},
+            "/me/profile/phones/{id}": {},
+            "/me/profile/positions": {},
+            "/me/profile/positions/{id}": {},
+            "/me/profile/projects": {},
+            "/me/profile/projects/{id}": {},
+            "/me/profile/publications": {},
+            "/me/profile/publications/{id}": {},
+            "/me/profile/skills": {},
+            "/me/profile/skills/{id}": {},
+            "/me/profile/webaccounts": {},
+            "/me/profile/webaccounts/{id}": {},
+            "/me/profile/websites": {},
+            "/me/profile/websites/{id}": {},
+            "/me/responsibilities": {},
+            "/users/{id}/profile": {},
+            "/users/{id}/profile/account": {},
+            "/users/{id}/profile/account/{id}": {},
+            "/users/{id}/profile/addresses": {},
+            "/users/{id}/profile/addresses/{id}": {},
+            "/users/{id}/profile/anniversaries": {},
+            "/users/{id}/profile/anniversaries/{id}": {},
+            "/users/{id}/profile/awards": {},
+            "/users/{id}/profile/awards/{id}": {},
+            "/users/{id}/profile/certifications": {},
+            "/users/{id}/profile/certifications/{id}": {},
+            "/users/{id}/profile/educationalactivities": {},
+            "/users/{id}/profile/educationalactivities/{id}": {},
+            "/users/{id}/profile/emails": {},
+            "/users/{id}/profile/emails/{id}": {},
+            "/users/{id}/profile/interests": {},
+            "/users/{id}/profile/interests/{id}": {},
+            "/users/{id}/profile/languages": {},
+            "/users/{id}/profile/languages/{id}": {},
+            "/users/{id}/profile/names/{id}": {},
+            "/users/{id}/profile/notes": {},
+            "/users/{id}/profile/patents": {},
+            "/users/{id}/profile/patents/{id}": {},
+            "/users/{id}/profile/phones": {},
+            "/users/{id}/profile/phones/{id}": {},
+            "/users/{id}/profile/positions": {},
+            "/users/{id}/profile/positions/{id}": {},
+            "/users/{id}/profile/projects": {},
+            "/users/{id}/profile/projects/{id}": {},
+            "/users/{id}/profile/publications": {},
+            "/users/{id}/profile/publications/{id}": {},
+            "/users/{id}/profile/skills": {},
+            "/users/{id}/profile/skills/{id}": {},
+            "/users/{id}/profile/webaccounts": {},
+            "/users/{id}/profile/webaccounts/{id}": {},
+            "/users/{id}/profile/websites": {},
+            "/users/{id}/profile/websites/{id}": {},
+            "/users/{id}/responsibilities": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/names": {},
+            "/users/{id}/profile/names": {}
+          }
+        }
+      ],
+      "ownerEmail": ""
+    },
+    "User.ReadBasic.All": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Read all users\u0027 basic profiles",
+          "adminDescription": "Allows the app to read a basic set of profile properties of other users in your organization on behalf of the signed-in user. This includes display name, first and last name, email address and photo.",
+          "userDisplayName": "Read all users\u0027 basic profiles",
+          "userDescription": "Allows the app to read a basic set of profile properties of other users in your organization on your behalf. Includes display name, first and last name, email address and photo.",
+          "requiresAdminConsent": false
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/{id}/approleassignments": {},
+            "/me/oauth2permissiongrants": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/oauth2permissiongrants": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me": {},
+            "/users": {},
+            "/users/delta": {},
+            "/users/{id}": {},
+            "/organization/{id}/branding": {},
+            "/organization/{id}/branding/localizations/{id}": {},
+            "/organization/{id}/branding/localizations": {},
+            "/me/findroomlists": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/findrooms": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/findrooms(roomlist={value})": {},
+            "/me/outlook/supportedlanguages": {},
+            "/me/outlook/supportedtimezones": {},
+            "/me/outlook/supportedtimezones(timezonestandard={value})": {},
+            "/users/{id}/displayname": {},
+            "/users/{id}/findroomlists": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/findrooms": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/findrooms(roomlist={value})": {},
+            "/users/{id}/givenname": {},
+            "/users/{id}/id": {},
+            "/users/{id}/identities": {},
+            "/users/{id}/mail": {},
+            "/users/{id}/outlook/supportedlanguages": {},
+            "/users/{id}/outlook/supportedtimezones": {},
+            "/users/{id}/outlook/supportedtimezones(timezonestandard={value})": {},
+            "/users/{id}/surname": {},
+            "/users/{id}/userprincipalname": {},
+            "/me/accountenabled": {},
+            "/me/agegroup": {},
+            "/me/assignedlicenses": {},
+            "/me/assignedplans": {},
+            "/me/businessphones": {},
+            "/me/city": {},
+            "/me/companyname": {},
+            "/me/consentprovidedforminor": {},
+            "/me/country": {},
+            "/me/createddatetime": {},
+            "/me/creationtype": {},
+            "/me/deleteddatetime": {},
+            "/me/department": {},
+            "/me/devicekeys": {},
+            "/me/displayname": {},
+            "/me/employeeid": {},
+            "/me/externaluserstate": {},
+            "/me/externaluserstatechangedatetime": {},
+            "/me/faxnumber": {},
+            "/me/givenname": {},
+            "/me/id": {},
+            "/me/identities": {},
+            "/me/imaddresses": {},
+            "/me/isresourceaccount": {},
+            "/me/jobtitle": {},
+            "/me/legalagegroupclassification": {},
+            "/me/mail": {},
+            "/me/mailnickname": {},
+            "/me/mobilephone": {},
+            "/me/officelocation": {},
+            "/me/onpremisesdistinguishedname": {},
+            "/me/onpremisesdomainname": {},
+            "/me/onpremisesextensionattributes": {},
+            "/me/onpremisesimmutableid": {},
+            "/me/onpremiseslastsyncdatetime": {},
+            "/me/onpremisesprovisioningerrors": {},
+            "/me/onpremisessamaccountname": {},
+            "/me/onpremisessecurityidentifier": {},
+            "/me/onpremisessyncenabled": {},
+            "/me/onpremisesuserprincipalname": {},
+            "/me/othermails": {},
+            "/me/passwordpolicies": {},
+            "/me/passwordprofile": {},
+            "/me/postalcode": {},
+            "/me/preferreddatalocation": {},
+            "/me/provisionedplans": {},
+            "/me/proxyaddresses": {},
+            "/me/refreshtokensvalidfromdatetime": {},
+            "/me/showinaddresslist": {},
+            "/me/signinsessionsvalidfromdatetime": {},
+            "/me/state": {},
+            "/me/streetaddress": {},
+            "/me/surname": {},
+            "/me/usagelocation": {},
+            "/me/userprincipalname": {},
+            "/me/usertype": {}
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/contacts/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/contacts/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/devices/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/devices/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/directoryobjects/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/directoryobjects/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/groups/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/groups/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE",
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/notes/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/responsibilities/{id}": {},
+            "/users/{id}/profile/notes/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/responsibilities/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/account": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/account/{id}": {},
+            "/me/profile/addresses": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/addresses/{id}": {},
+            "/me/profile/anniversaries": {},
+            "/me/profile/anniversaries/{id}": {},
+            "/me/profile/awards": {},
+            "/me/profile/awards/{id}": {},
+            "/me/profile/certifications": {},
+            "/me/profile/certifications/{id}": {},
+            "/me/profile/educationalactivities": {},
+            "/me/profile/educationalactivities/{id}": {},
+            "/me/profile/emails": {},
+            "/me/profile/emails/{id}": {},
+            "/me/profile/interests": {},
+            "/me/profile/interests/{id}": {},
+            "/me/profile/languages": {},
+            "/me/profile/languages/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/names/{id}": {},
+            "/me/profile/notes": {},
+            "/me/profile/patents": {},
+            "/me/profile/patents/{id}": {},
+            "/me/profile/phones": {},
+            "/me/profile/phones/{id}": {},
+            "/me/profile/positions": {},
+            "/me/profile/positions/{id}": {},
+            "/me/profile/projects": {},
+            "/me/profile/projects/{id}": {},
+            "/me/profile/publications": {},
+            "/me/profile/publications/{id}": {},
+            "/me/profile/skills": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/skills/{id}": {},
+            "/me/profile/webaccounts": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/webaccounts/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/websites": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/websites/{id}": {},
+            "/me/responsibilities": {},
+            "/users/{id}/profile": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/account": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/account/{id}": {},
+            "/users/{id}/profile/addresses": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/addresses/{id}": {},
+            "/users/{id}/profile/anniversaries": {},
+            "/users/{id}/profile/anniversaries/{id}": {},
+            "/users/{id}/profile/awards": {},
+            "/users/{id}/profile/awards/{id}": {},
+            "/users/{id}/profile/certifications": {},
+            "/users/{id}/profile/certifications/{id}": {},
+            "/users/{id}/profile/educationalactivities": {},
+            "/users/{id}/profile/educationalactivities/{id}": {},
+            "/users/{id}/profile/emails": {},
+            "/users/{id}/profile/emails/{id}": {},
+            "/users/{id}/profile/interests": {},
+            "/users/{id}/profile/interests/{id}": {},
+            "/users/{id}/profile/languages": {},
+            "/users/{id}/profile/languages/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/names/{id}": {},
+            "/users/{id}/profile/notes": {},
+            "/users/{id}/profile/patents": {},
+            "/users/{id}/profile/patents/{id}": {},
+            "/users/{id}/profile/phones": {},
+            "/users/{id}/profile/phones/{id}": {},
+            "/users/{id}/profile/positions": {},
+            "/users/{id}/profile/positions/{id}": {},
+            "/users/{id}/profile/projects": {},
+            "/users/{id}/profile/projects/{id}": {},
+            "/users/{id}/profile/publications": {},
+            "/users/{id}/profile/publications/{id}": {},
+            "/users/{id}/profile/skills": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/skills/{id}": {},
+            "/users/{id}/profile/webaccounts": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/webaccounts/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/websites": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/websites/{id}": {},
+            "/users/{id}/responsibilities": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/names": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/names": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/translateexchangeids": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/translateexchangeids": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            }
+          }
+        }
+      ],
+      "ownerEmail": ""
+    },
+    "User.ReadWrite": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Read and write access to user profile",
+          "adminDescription": "Allows the app to read your profile. It also allows the app to update your profile information on your behalf.",
+          "userDisplayName": "Read and update your profile",
+          "userDescription": "Allows the app to read your profile, and discover your group membership, reports and manager. It also allows the app to update your profile information on your behalf.",
+          "requiresAdminConsent": false
+        },
+        "DelegatedPersonal": {
+          "adminDisplayName": "Read and write access to user profile",
+          "adminDescription": "Allows the app to read your profile. It also allows the app to update your profile information on your behalf.",
+          "userDisplayName": "Read and update your profile",
+          "userDescription": "Allows the app to read your profile, and discover your group membership, reports and manager. It also allows the app to update your profile information on your behalf.",
+          "requiresAdminConsent": false
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me": {},
+            "/me/createdobjects": {},
+            "/users/{id}/createdobjects": {}
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/delta": {},
+            "/users/{id}/usagerights": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/users/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/me/settings/contactmergesuggestions": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/settings/iteminsights": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/settings/contactmergesuggestions": {},
+            "/users/{id}/settings/iteminsights": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/me/invalidateallrefreshtokens": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/validatepassword": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/invalidateallrefreshtokens": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "PATCH",
+            "PUT"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/settings/regionalandlanguagesettings": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE",
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/notes/{id}": {},
+            "/me/responsibilities/{id}": {},
+            "/users/{id}/profile/notes/{id}": {},
+            "/users/{id}/responsibilities/{id}": {},
+            "/me/profile/account/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/addresses/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/anniversaries/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/awards/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/certifications/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/educationalactivities/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/emails/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/interests/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/languages/{id}": {},
+            "/me/profile/names/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/patents/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/phones/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/positions/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/projects/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/publications/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/skills/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/webaccounts/{id}": {},
+            "/me/profile/websites/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/account/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/addresses/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/anniversaries/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/awards/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/certifications/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/educationalactivities/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/emails/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/interests/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/languages/{id}": {},
+            "/users/{id}/profile/names/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/patents/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/phones/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/positions/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/projects/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/publications/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/skills/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/webaccounts/{id}": {},
+            "/users/{id}/profile/websites/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "DELETE"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile": {},
+            "/users/{id}/profile": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/account": {},
+            "/me/profile/addresses": {},
+            "/me/profile/anniversaries": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/awards": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/certifications": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/educationalactivities": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/emails": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/interests": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/languages": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/names": {},
+            "/me/profile/notes": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/patents": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/phones": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/positions": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/projects": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/publications": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/skills": {},
+            "/me/profile/webaccounts": {},
+            "/me/profile/websites": {},
+            "/me/responsibilities": {},
+            "/users/{id}/profile/account": {},
+            "/users/{id}/profile/addresses": {},
+            "/users/{id}/profile/anniversaries": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/awards": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/certifications": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/educationalactivities": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/emails": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/interests": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/languages": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/names": {},
+            "/users/{id}/profile/notes": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/patents": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/phones": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/positions": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/projects": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/publications": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/skills": {},
+            "/users/{id}/profile/webaccounts": {},
+            "/users/{id}/profile/websites": {},
+            "/users/{id}/responsibilities": {}
+          }
+        },
+        {
+          "methods": [
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/me/settings": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/settings": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "PATCH",
+            "PUT"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/{id}/photo": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/photo": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/translateexchangeids": {},
+            "/users/{id}/translateexchangeids": {}
+          }
+        }
+      ],
+      "ownerEmail": ""
+    },
+    "User.ReadWrite.All": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Read and write all users\u0027 full profiles",
+          "adminDescription": "Allows the app to read and write the full set of profile properties, reports, and managers of other users in your organization, on behalf of the signed-in user.",
+          "userDisplayName": "Read and write all users\u0027 full profiles",
+          "userDescription": "Allows the app to read and write the full set of profile properties, reports, and managers of other users in your organization, on your behalf.",
+          "requiresAdminConsent": true
+        },
+        "Application": {
+          "adminDisplayName": "Read and write all users\u0027 full profiles",
+          "adminDescription": "Allows the app to read and update user profiles without a signed in user.",
+          "requiresAdminConsent": true
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/directory/deleteditems/microsoft.graph.application": {},
+            "/directory/deleteditems/microsoft.graph.group": {},
+            "/directory/deleteditems/microsoft.graph.serviceprincipal": {},
+            "/directory/deleteditems/microsoft.graph.user": {},
+            "/me": {},
+            "/me/createdobjects": {},
+            "/me/directreports": {},
+            "/me/joinedteams": {},
+            "/me/licensedetails": {},
+            "/me/manager": {},
+            "/me/ownedobjects": {},
+            "/me/registereddevices": {},
+            "/users/delta": {},
+            "/users/{id}/createdobjects": {},
+            "/users/{id}/directreports": {},
+            "/users/{id}/joinedteams": {},
+            "/users/{id}/licensedetails": {},
+            "/users/{id}/owneddevices": {},
+            "/users/{id}/ownedobjects": {},
+            "/users/{id}/registereddevices": {},
+            "/users/{id}/usagerights": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "DELETE"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/directory/deleteditems/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/contacts/{id}/checkmembergroups": {},
+            "/contacts/{id}/checkmemberobjects": {},
+            "/contacts/{id}/getmemberobjects": {},
+            "/devices/{id}/checkmembergroups": {},
+            "/devices/{id}/checkmemberobjects": {},
+            "/devices/{id}/getmemberobjects": {},
+            "/directoryobjects/{id}/checkmembergroups": {},
+            "/directoryobjects/{id}/checkmemberobjects": {},
+            "/directoryobjects/{id}/getmemberobjects": {},
+            "/groups/{id}/checkmembergroups": {},
+            "/groups/{id}/checkmemberobjects": {},
+            "/groups/{id}/getmemberobjects": {},
+            "/me/checkmembergroups": {},
+            "/me/checkmemberobjects": {},
+            "/me/getmemberobjects": {},
+            "/serviceprincipals/{id}/checkmembergroups": {},
+            "/serviceprincipals/{id}/checkmemberobjects": {},
+            "/serviceprincipals/{id}/getmemberobjects": {},
+            "/users/{id}/checkmembergroups": {},
+            "/users/{id}/checkmemberobjects": {},
+            "/users/{id}/getmemberobjects": {},
+            "/directory/deleteditems/{id}/restore": {},
+            "/invitations": {},
+            "/me/revokesigninsessions": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/assignlicense": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/reprocesslicenseassignment": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/revokesigninsessions": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/me/translateexchangeids": {},
+            "/users/{id}/translateexchangeids": {}
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/directoryobjects/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "PATCH",
+            "DELETE"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "PUT"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/{id}/manager": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/organization/{id}/settings/iteminsights": {},
+            "/organization/{id}/settings/peopleinsights": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "PUT"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/{id}/settings/shiftpreferences": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/validatepassword": {}
+          }
+        },
+        {
+          "methods": [
+            "PATCH",
+            "PUT"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/settings/regionalandlanguagesettings": {}
+          }
+        },
+        {
+          "methods": [
+            "DELETE",
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/notes/{id}": {},
+            "/me/responsibilities/{id}": {},
+            "/users/{id}/profile/notes/{id}": {},
+            "/users/{id}/responsibilities/{id}": {},
+            "/me/profile/account/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/addresses/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/anniversaries/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/awards/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/certifications/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/educationalactivities/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/emails/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/interests/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/languages/{id}": {},
+            "/me/profile/names/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/patents/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/phones/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/positions/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/projects/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/publications/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/skills/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/webaccounts/{id}": {},
+            "/me/profile/websites/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/account/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/addresses/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/anniversaries/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/awards/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/certifications/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/educationalactivities/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/emails/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/interests/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/languages/{id}": {},
+            "/users/{id}/profile/names/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/patents/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/phones/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/positions/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/projects/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/publications/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/skills/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/webaccounts/{id}": {},
+            "/users/{id}/profile/websites/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "DELETE"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile": {},
+            "/users/{id}/profile": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/account": {},
+            "/me/profile/addresses": {},
+            "/me/profile/anniversaries": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/awards": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/certifications": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/educationalactivities": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/emails": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/interests": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/languages": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/names": {},
+            "/me/profile/notes": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/patents": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/phones": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/positions": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/projects": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/publications": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/skills": {},
+            "/me/profile/webaccounts": {},
+            "/me/profile/websites": {},
+            "/me/responsibilities": {},
+            "/users/{id}/profile/account": {},
+            "/users/{id}/profile/addresses": {},
+            "/users/{id}/profile/anniversaries": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/awards": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/certifications": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/educationalactivities": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/emails": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/interests": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/languages": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/names": {},
+            "/users/{id}/profile/notes": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/patents": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/phones": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/positions": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/projects": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/publications": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/skills": {},
+            "/users/{id}/profile/webaccounts": {},
+            "/users/{id}/profile/websites": {},
+            "/users/{id}/responsibilities": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/me/settings": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/settings": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "PATCH",
+            "PUT"
+          ],
+          "schemeKeys": [
+            "Application"
+          ],
+          "paths": {
+            "/users/{id}/photo": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            }
+          }
+        }
+      ],
+      "ownerEmail": ""
+    }
+  }
+}

--- a/kibaliTests/KibaliTests.csproj
+++ b/kibaliTests/KibaliTests.csproj
@@ -29,7 +29,25 @@
     <None Update="GraphPermissions.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="InvalidPermissions\Directory.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="InvalidPermissions\User.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="InvalidUser.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="UserAuthenticationMethod.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="ValidPermissions\Directory.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="ValidPermissions\User.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="ValidUser.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/kibaliTests/ValidPermissions/Directory.json
+++ b/kibaliTests/ValidPermissions/Directory.json
@@ -1,0 +1,1424 @@
+{
+  "$schema": "https://microsoftgraph.github.io/msgraph-metadata/graph-permissions-schema.json",
+  "permissions": {
+    "Directory.AccessAsUser.All": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Access directory as the signed in user",
+          "adminDescription": "Allows the app to have the same access to information in the directory as the signed-in user.",
+          "userDisplayName": "Access the directory as you",
+          "userDescription": "Allows the app to have the same access to information in your work or school directory as you do.",
+          "requiresAdminConsent": true
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/devices": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/devices/{id}/registeredowners": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/devices/{id}/registeredusers": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/privilegedapproval": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/changepassword": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/privilegedroleassignments/{id}/makeeligible": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/privilegedroleassignments/{id}/makepermanent": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/privilegedroles/{id}/selfactivate": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/privilegedroles/{id}/selfdeactivate": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/changepassword": {}
+          }
+        },
+        {
+          "methods": [
+            "PATCH",
+            "DELETE"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/devices/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/devices/{id}/registeredowners/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/devices/{id}/registeredusers/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE",
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/privilegedroleassignments/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/privilegedapproval/myrequests": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/privilegedoperationevents": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/privilegedroleassignments/my": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/privilegedroleassignments/{id}/roleinfo": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/privilegedroles": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/privilegedroles/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/privilegedroles/{id}/assignments": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/privilegedroles/{id}/settings": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/privilegedroleassignments": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        }
+      ],
+      "ownerEmail": ""
+    },
+    "Directory.Read.All": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Read directory data",
+          "adminDescription": "Allows the app to read data in your organization\u0027s directory, such as users, groups and apps.",
+          "userDisplayName": "Read directory data",
+          "userDescription": "Allows the app to read data in your organization\u0027s directory.",
+          "requiresAdminConsent": true
+        },
+        "Application": {
+          "adminDisplayName": "Read directory data",
+          "adminDescription": "Allows the app to read data in your organization\u0027s directory, such as users, groups and apps, without a signed-in user.",
+          "requiresAdminConsent": true
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/administrativeunits": {},
+            "/administrativeunits/{id}": {},
+            "/administrativeunits/{id}/members": {},
+            "/administrativeunits/{id}/members/{id}": {},
+            "/directory/administrativeunits": {},
+            "/directory/administrativeunits/{id}": {},
+            "/groups/{id}/approleassignments": {},
+            "/users/{id}/approleassignments": {},
+            "/serviceprincipals/{id}/approleassignments": {},
+            "/applications": {},
+            "/applications/delta": {},
+            "/applications/{id}": {},
+            "/applications/{id}/extensionproperties": {},
+            "/directory/deleteditems/microsoft.graph.application": {},
+            "/directory/deleteditems/microsoft.graph.group": {},
+            "/directory/deleteditems/microsoft.graph.serviceprincipal": {},
+            "/directory/deleteditems/microsoft.graph.user": {},
+            "/directory/deleteditems/{id}": {},
+            "/policies/claimsmappingpolicies/{id}/appliesto": {},
+            "/policies/homerealmdiscoverypolicies/{id}/appliesto": {},
+            "/policies/tokenissuancepolicies/{id}/appliesto": {},
+            "/policies/tokenlifetimepolicies/{id}/appliesto": {},
+            "/serviceprincipals/delta": {},
+            "/serviceprincipals/{id}": {},
+            "/serviceprincipals/{id}/createdobjects": {},
+            "/serviceprincipals/{id}/delegatedpermissionclassifications": {},
+            "/serviceprincipals/{id}/memberof": {},
+            "/serviceprincipals/{id}/ownedobjects": {},
+            "/serviceprincipals/{id}/transitivememberof": {},
+            "/directoryobjects/{id}": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals": {},
+            "/auditlogs/directoryaudits": {},
+            "/auditlogs/directoryaudits/{id}": {},
+            "/auditlogs/provisioning": {},
+            "/auditlogs/signins": {},
+            "/auditlogs/signins/{id}": {},
+            "/teams/{id}/channels": {},
+            "/teams/{id}/channels/{id}": {},
+            "/rolemanagement/cloudpc/roledefinitions": {},
+            "/rolemanagement/cloudpc/roledefinitions/{id}": {},
+            "/rolemanagement/devicemanagement/roledefinitions": {},
+            "/rolemanagement/devicemanagement/roledefinitions/{id}": {},
+            "/rolemanagement/directory/roledefinitions": {},
+            "/rolemanagement/directory/roledefinitions/{id}": {},
+            "/rolemanagement/entitlementmanagement/roledefinitions": {},
+            "/rolemanagement/entitlementmanagement/roledefinitions/{id}": {},
+            "/oauth2permissiongrants/{id}": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/me/oauth2permissiongrants": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/oauth2permissiongrants": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/oauth2permissiongrants": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/oauth2permissiongrants": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/devices": {},
+            "/devices/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/devices/{id}/memberof": {},
+            "/devices/{id}/registeredowners": {},
+            "/devices/{id}/registeredusers": {},
+            "/devices/{id}/transitivememberof": {},
+            "/devices/{id}/usagerights": {},
+            "/organization": {},
+            "/administrativeunits/{id}/scopedrolemembers": {},
+            "/administrativeunits/{id}/scopedrolemembers/{id}": {},
+            "/contacts": {},
+            "/contacts/delta": {},
+            "/contacts/{id}": {},
+            "/contacts/{id}/directreports": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/contacts/{id}/manager": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/contacts/{id}/memberof": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/contacts/{id}/transitivereports/$count": {},
+            "/contracts": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/contracts/{id}": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/dataclassification/jobs": {},
+            "/dataclassification/jobs/{id}": {},
+            "/dataclassification/sensitivetypes": {},
+            "/dataclassification/sensitivetypes/{id}": {},
+            "/directoryroles": {},
+            "/directoryroles/delta": {},
+            "/directoryroles/roletemplateid={roletemplateid}": {},
+            "/directoryroles/roletemplateid={roletemplateid}/members": {},
+            "/directoryroles/roletemplateid={roletemplateid}/scopedmembers": {},
+            "/directoryroles/{id}": {},
+            "/directoryroles/{id}/members": {},
+            "/directoryroles/{id}/scopedmembers": {},
+            "/directoryroletemplates": {},
+            "/directoryroletemplates/{id}": {},
+            "/directorysettingtemplates": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/directorysettingtemplates/{id}": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/domains": {},
+            "/domains/{id}": {},
+            "/education/classes/{id}/group": {},
+            "/education/me/user": {},
+            "/education/schools/{id}/administrativeunit": {},
+            "/education/users/{id}/user": {},
+            "/grouplifecyclepolicies": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/grouplifecyclepolicies/{id}": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/groups": {},
+            "/groups/delta": {},
+            "/groups/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/groups/{id}/grouplifecyclepolicies": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/groups/{id}/memberof": {},
+            "/groups/{id}/members": {},
+            "/groups/{id}/owners": {},
+            "/groups/{id}/settings": {},
+            "/groups/{id}/settings/{id}": {},
+            "/groups/{id}/transitivememberof": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/groups/{id}/transitivemembers": {},
+            "/groupsettings": {},
+            "/groupsettings/{id}": {},
+            "/me": {},
+            "/me/createdobjects": {},
+            "/me/directreports": {},
+            "/me/joinedteams": {},
+            "/me/licensedetails": {},
+            "/me/manager": {},
+            "/me/memberof": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/ownedobjects": {},
+            "/me/registereddevices": {},
+            "/me/scopedrolememberof": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/policies/adminconsentrequestpolicy": {},
+            "/policies/permissiongrantpolicies/{id}/excludes": {},
+            "/policies/permissiongrantpolicies/{id}/includes": {},
+            "/rolemanagement/directory/roleassignments": {},
+            "/rolemanagement/directory/roleassignments/{id}": {},
+            "/rolemanagement/directory/transitiveroleassignments": {},
+            "/rolemanagement/entitlementmanagement/roleassignments": {},
+            "/rolemanagement/entitlementmanagement/roleassignments/{id}": {},
+            "/settings": {},
+            "/settings/{id}": {},
+            "/subscribedskus": {},
+            "/subscribedskus/{id}": {},
+            "/teams/{id}": {},
+            "/teams/{id}/channels/{id}/tabs": {},
+            "/teams/{id}/channels/{id}/tabs/{id}": {},
+            "/teams/{id}/installedapps": {},
+            "/teams/{id}/installedapps/{id}": {},
+            "/users": {},
+            "/users/delta": {},
+            "/users/{id}": {},
+            "/users/{id}/createdobjects": {},
+            "/users/{id}/directreports": {},
+            "/users/{id}/joinedteams": {},
+            "/users/{id}/licensedetails": {},
+            "/users/{id}/manager": {},
+            "/users/{id}/memberof": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/owneddevices": {},
+            "/users/{id}/ownedobjects": {},
+            "/users/{id}/registereddevices": {},
+            "/users/{id}/scopedrolememberof": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/transitivememberof": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/transitivereports/$count": {},
+            "/users/{id}/usagerights": {}
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/appcatalogs/teamsapps": {},
+            "/applications/{id}/extensionproperties/{id}": {},
+            "/applications/{id}/synchronization/templates/{id}/schema": {},
+            "/serviceprincipals/{id}/synchronization/jobs/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/synchronization/jobs/{id}/schema": {},
+            "/applications/{id}/synchronization/templates": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/applications/{id}/synchronization/templates/{id}": {},
+            "/applications/{id}/synchronization/templates/{id}/schema/filteroperators": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/applications/{id}/synchronization/templates/{id}/schema/functions": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/synchronization/jobs/{id}/schema/filteroperators": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/synchronization/jobs/{id}/schema/functions": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/synchronization/templates": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/synchronization/templates/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/synchronization/templates/{id}/schema": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/synchronization/templates/{id}/schema/filteroperators": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/synchronization/templates/{id}/schema/functions": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/privilegedroleassignmentrequests": {},
+            "/administrativeunits/delta": {},
+            "/oauth2permissiongrants/delta": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST",
+            "GET"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/serviceprincipals/{id}/approleassignedto": {},
+            "/applications/{id}/owners": {},
+            "/serviceprincipals/{id}/owners": {}
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/contacts/{id}/checkmembergroups": {},
+            "/contacts/{id}/checkmemberobjects": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/contacts/{id}/getmembergroups": {},
+            "/contacts/{id}/getmemberobjects": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/devices/{id}/checkmembergroups": {},
+            "/devices/{id}/checkmemberobjects": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/devices/{id}/getmembergroups": {},
+            "/devices/{id}/getmemberobjects": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/directoryobjects/{id}/checkmembergroups": {},
+            "/directoryobjects/{id}/checkmemberobjects": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/directoryobjects/{id}/getmembergroups": {},
+            "/directoryobjects/{id}/getmemberobjects": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/groups/{id}/checkmembergroups": {},
+            "/groups/{id}/checkmemberobjects": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/groups/{id}/getmembergroups": {},
+            "/groups/{id}/getmemberobjects": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/me/checkmembergroups": {},
+            "/me/checkmemberobjects": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/me/getmembergroups": {},
+            "/me/getmemberobjects": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/checkmembergroups": {},
+            "/serviceprincipals/{id}/checkmemberobjects": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/getmembergroups": {},
+            "/serviceprincipals/{id}/getmemberobjects": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/checkmembergroups": {},
+            "/users/{id}/checkmemberobjects": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/getmembergroups": {},
+            "/users/{id}/getmemberobjects": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/createpasswordsinglesignoncredentials": {},
+            "/serviceprincipals/{id}/deletepasswordsinglesignoncredentials": {},
+            "/serviceprincipals/{id}/getpasswordsinglesignoncredentials": {},
+            "/serviceprincipals/{id}/updatepasswordsinglesignoncredentials": {},
+            "/dataclassification/classifyfile": {},
+            "/dataclassification/classifytext": {},
+            "/directoryobjects/getbyids": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/directoryobjects/validateproperties": {}
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/groups/evaluatedynamicmembership": {},
+            "/groups/{id}/evaluatedynamicmembership": {},
+            "/privilegedroleassignmentrequests/my": {}
+          }
+        }
+      ],
+      "ownerEmail": ""
+    },
+    "Directory.ReadWrite.All": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Read and write directory data",
+          "adminDescription": "Allows the app to read and write data in your organization\u0027s directory, such as users, and groups.  It does not allow the app to delete users or groups, or reset user passwords.",
+          "userDisplayName": "Read and write directory data",
+          "userDescription": "Allows the app to read and write data in your organization\u0027s directory, such as other users, groups.  It does not allow the app to delete users or groups, or reset user passwords.",
+          "requiresAdminConsent": true
+        },
+        "Application": {
+          "adminDisplayName": "Read and write directory data",
+          "adminDescription": "Allows the app to read and write data in your organization\u0027s directory, such as users, and groups, without a signed-in user.  Does not allow user or group deletion.",
+          "requiresAdminConsent": true
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/administrativeunits": {},
+            "/administrativeunits/{id}": {},
+            "/administrativeunits/{id}/members/{id}": {},
+            "/directory/administrativeunits": {},
+            "/directory/administrativeunits/{id}": {},
+            "/groups/{id}/approleassignments": {},
+            "/applications/delta": {},
+            "/directory/deleteditems/microsoft.graph.application": {},
+            "/directory/deleteditems/microsoft.graph.group": {},
+            "/directory/deleteditems/microsoft.graph.serviceprincipal": {},
+            "/directory/deleteditems/microsoft.graph.user": {},
+            "/serviceprincipals/delta": {},
+            "/serviceprincipals/{id}/createdobjects": {},
+            "/serviceprincipals/{id}/memberof": {},
+            "/serviceprincipals/{id}/ownedobjects": {},
+            "/serviceprincipals/{id}/transitivememberof": {},
+            "/rolemanagement/entitlementmanagement/roledefinitions": {},
+            "/rolemanagement/entitlementmanagement/roledefinitions/{id}": {},
+            "/serviceprincipals/{id}/oauth2permissiongrants": {},
+            "/devices": {},
+            "/devices/{id}/memberof": {},
+            "/devices/{id}/registeredowners": {},
+            "/devices/{id}/registeredusers": {},
+            "/devices/{id}/transitivememberof": {},
+            "/devices/{id}/usagerights": {},
+            "/organization": {},
+            "/administrativeunits/{id}/scopedrolemembers": {},
+            "/administrativeunits/{id}/scopedrolemembers/{id}": {},
+            "/contacts": {},
+            "/contacts/delta": {},
+            "/contacts/{id}": {},
+            "/contacts/{id}/directreports": {},
+            "/contacts/{id}/manager": {},
+            "/contacts/{id}/memberof": {},
+            "/contracts": {},
+            "/contracts/{id}": {},
+            "/directoryroles": {},
+            "/directoryroles/delta": {},
+            "/directoryroles/roletemplateid={roletemplateid}": {},
+            "/directoryroles/roletemplateid={roletemplateid}/members": {},
+            "/directoryroles/roletemplateid={roletemplateid}/scopedmembers": {},
+            "/directoryroles/{id}": {},
+            "/directoryroles/{id}/members": {},
+            "/directoryroles/{id}/scopedmembers": {},
+            "/directoryroletemplates": {},
+            "/directoryroletemplates/{id}": {},
+            "/directorysettingtemplates": {},
+            "/directorysettingtemplates/{id}": {},
+            "/groups/delta": {},
+            "/groups/{id}/grouplifecyclepolicies": {},
+            "/groups/{id}/memberof": {},
+            "/groups/{id}/transitivememberof": {},
+            "/me": {},
+            "/me/createdobjects": {},
+            "/me/directreports": {},
+            "/me/joinedteams": {},
+            "/me/licensedetails": {},
+            "/me/manager": {},
+            "/me/memberof": {},
+            "/me/ownedobjects": {},
+            "/me/registereddevices": {},
+            "/me/scopedrolememberof": {},
+            "/rolemanagement/directory/roleassignments": {},
+            "/rolemanagement/directory/roleassignments/{id}": {},
+            "/rolemanagement/directory/transitiveroleassignments": {},
+            "/rolemanagement/entitlementmanagement/roleassignments": {},
+            "/rolemanagement/entitlementmanagement/roleassignments/{id}": {},
+            "/subscribedskus": {},
+            "/subscribedskus/{id}": {},
+            "/users/delta": {},
+            "/users/{id}/createdobjects": {},
+            "/users/{id}/directreports": {},
+            "/users/{id}/joinedteams": {},
+            "/users/{id}/licensedetails": {},
+            "/users/{id}/memberof": {},
+            "/users/{id}/owneddevices": {},
+            "/users/{id}/ownedobjects": {},
+            "/users/{id}/registereddevices": {},
+            "/users/{id}/scopedrolememberof": {},
+            "/users/{id}/transitivememberof": {},
+            "/users/{id}/usagerights": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/administrativeunits/{id}/members": {},
+            "/serviceprincipals/{id}/approleassignedto": {},
+            "/serviceprincipals/{id}/approleassignments": {},
+            "/applications": {},
+            "/applications/{id}/extensionproperties": {},
+            "/applications/{id}/owners": {},
+            "/serviceprincipals/{id}/owners": {},
+            "/serviceprincipals": {},
+            "/serviceprincipals/{id}/synchronization/jobs": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/teams/{id}/channels": {},
+            "/rolemanagement/cloudpc/roledefinitions": {},
+            "/rolemanagement/devicemanagement/roledefinitions": {},
+            "/rolemanagement/directory/roledefinitions": {},
+            "/oauth2permissiongrants": {},
+            "/grouplifecyclepolicies": {},
+            "/groups": {},
+            "/groups/{id}/settings": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/settings": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/teams/{id}/channels/{id}/tabs": {},
+            "/teams/{id}/installedapps": {},
+            "/users": {},
+            "/onpremisespublishingprofiles/applicationproxy/connectorgroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/appcatalogs/teamsapps": {},
+            "/onpremisespublishingprofiles/applicationproxy/connectorgroups/{id}/members": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/onpremisespublishingprofiles/applicationproxy/connectors/{id}/memberof": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/policies/featurerolloutpolicies": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "DELETE",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/applications/{id}": {},
+            "/serviceprincipals/{id}": {},
+            "/teams/{id}/channels/{id}": {},
+            "/rolemanagement/cloudpc/roledefinitions/{id}": {},
+            "/rolemanagement/devicemanagement/roledefinitions/{id}": {},
+            "/rolemanagement/directory/roledefinitions/{id}": {},
+            "/oauth2permissiongrants/{id}": {},
+            "/grouplifecyclepolicies/{id}": {},
+            "/groups/{id}/settings/{id}": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/settings/{id}": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/teams/{id}/channels/{id}/tabs/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/applications/{id}/extensionproperties/{id}": {},
+            "/applications/{id}/owners/{id}": {},
+            "/serviceprincipals/{id}/owners/{id}": {},
+            "/groups/{id}/members/{id}": {},
+            "/groups/{id}/owners/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "DELETE"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/directory/deleteditems/{id}": {},
+            "/serviceprincipals/{id}/synchronization/jobs/{id}": {},
+            "/teams/{id}/installedapps/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application"
+          ],
+          "paths": {
+            "/schemaextensions": {}
+          }
+        },
+        {
+          "methods": [
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "Application"
+          ],
+          "paths": {
+            "/schemaextensions/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/contacts/{id}/checkmembergroups": {},
+            "/contacts/{id}/checkmemberobjects": {},
+            "/contacts/{id}/getmembergroups": {},
+            "/contacts/{id}/getmemberobjects": {},
+            "/devices/{id}/checkmembergroups": {},
+            "/devices/{id}/checkmemberobjects": {},
+            "/devices/{id}/getmembergroups": {},
+            "/devices/{id}/getmemberobjects": {},
+            "/directoryobjects/{id}/checkmembergroups": {},
+            "/directoryobjects/{id}/checkmemberobjects": {},
+            "/directoryobjects/{id}/getmembergroups": {},
+            "/directoryobjects/{id}/getmemberobjects": {},
+            "/groups/{id}/checkmembergroups": {},
+            "/groups/{id}/checkmemberobjects": {},
+            "/groups/{id}/getmembergroups": {},
+            "/groups/{id}/getmemberobjects": {},
+            "/me/checkmembergroups": {},
+            "/me/checkmemberobjects": {},
+            "/me/getmembergroups": {},
+            "/me/getmemberobjects": {},
+            "/serviceprincipals/{id}/checkmembergroups": {},
+            "/serviceprincipals/{id}/checkmemberobjects": {},
+            "/serviceprincipals/{id}/getmembergroups": {},
+            "/serviceprincipals/{id}/getmemberobjects": {},
+            "/users/{id}/checkmembergroups": {},
+            "/users/{id}/checkmemberobjects": {},
+            "/users/{id}/getmembergroups": {},
+            "/users/{id}/getmemberobjects": {},
+            "/applications/{id}/addpassword": {},
+            "/applications/{id}/removepassword": {},
+            "/applicationtemplates/{id}/instantiate": {},
+            "/serviceprincipals/{id}/addkey": {},
+            "/serviceprincipals/{id}/addpassword": {},
+            "/serviceprincipals/{id}/addtokensigningcertificate": {},
+            "/serviceprincipals/{id}/createpasswordsinglesignoncredentials": {},
+            "/serviceprincipals/{id}/deletepasswordsinglesignoncredentials": {},
+            "/serviceprincipals/{id}/getpasswordsinglesignoncredentials": {},
+            "/serviceprincipals/{id}/removekey": {},
+            "/serviceprincipals/{id}/removepassword": {},
+            "/serviceprincipals/{id}/updatepasswordsinglesignoncredentials": {},
+            "/applications/{id}/synchronization/acquireaccesstoken": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/synchronization/acquireaccesstoken": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/synchronization/jobs/{id}/pause": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/synchronization/jobs/{id}/provisionondemand": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/synchronization/jobs/{id}/restart": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/synchronization/jobs/{id}/schema/directories/{id}/discover": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/synchronization/jobs/{id}/schema/parseexpression": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/synchronization/jobs/{id}/start": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/synchronization/jobs/{id}/validatecredentials": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/synchronization/templates/{id}/schema/parseexpression": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/groups/{id}/members": {},
+            "/groups/{id}/owners": {},
+            "/groupsettings": {},
+            "/directoryobjects/validateproperties": {},
+            "/grouplifecyclepolicies/renewgroup": {},
+            "/grouplifecyclepolicies/{id}/addgroup": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/grouplifecyclepolicies/{id}/removegroup": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/groups/{id}/assignlicense": {},
+            "/groups/{id}/renew": {},
+            "/invitations": {},
+            "/me/revokesigninsessions": {},
+            "/organization/{id}/activateservice": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/teams": {},
+            "/teams/87654321-0abc-zqf0-321456789q/installedapps": {},
+            "/teams/{id}/archive": {},
+            "/teams/{id}/clone": {},
+            "/teams/{id}/installedapps/{id}/upgrade": {},
+            "/teams/{id}/unarchive": {},
+            "/users/{id}/activateserviceplan": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/assignlicense": {},
+            "/users/{id}/reprocesslicenseassignment": {},
+            "/users/{id}/revokesigninsessions": {}
+          }
+        },
+        {
+          "methods": [
+            "DELETE",
+            "GET",
+            "PUT"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/applications/{id}/synchronization/templates/{id}/schema": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/synchronization/jobs/{id}/schema": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "Application"
+          ],
+          "paths": {
+            "/applications/{id}/synchronization/templates": {},
+            "/applications/{id}/synchronization/templates/{id}/schema/filteroperators": {},
+            "/applications/{id}/synchronization/templates/{id}/schema/functions": {},
+            "/serviceprincipals/{id}/synchronization/jobs/{id}/schema/filteroperators": {},
+            "/serviceprincipals/{id}/synchronization/jobs/{id}/schema/functions": {},
+            "/serviceprincipals/{id}/synchronization/templates": {},
+            "/serviceprincipals/{id}/synchronization/templates/{id}": {},
+            "/serviceprincipals/{id}/synchronization/templates/{id}/schema": {},
+            "/serviceprincipals/{id}/synchronization/templates/{id}/schema/filteroperators": {},
+            "/serviceprincipals/{id}/synchronization/templates/{id}/schema/functions": {},
+            "/group/{id}/settings": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/applications/{id}/synchronization/templates/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/devices/{id}": {},
+            "/groups/{id}": {},
+            "/teams/{id}": {},
+            "/users/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "PUT"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/serviceprincipals/{id}/synchronization/secrets": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/groups/{id}/team": {}
+          }
+        },
+        {
+          "methods": [
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/teams/{id}/channels/{id}/members/{id}": {},
+            "/teams/{id}/members/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "DELETE",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/groupsettings/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "PUT"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/policies/adminconsentrequestpolicy": {},
+            "/users/{id}/manager": {}
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/appcatalogs/teamsapps/{id}": {},
+            "/appcatalogs/teamsapps/{id}/appdefinitions/{id}": {},
+            "/onpremisespublishingprofiles/{id}/agents/{id}/agentgroups/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/policies/featurerolloutpolicies/{id}/appliesto/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE",
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/onpremisespublishingprofiles/applicationproxy/connectorgroups/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/policies/featurerolloutpolicies/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE",
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/onpremisespublishingprofiles/{id}/agentgroups/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/onpremisespublishingprofiles/applicationproxy/connectorgroups/{id}/applications": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/onpremisespublishingprofiles/applicationproxy/connectors": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/onpremisespublishingprofiles/applicationproxy/connectors/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/onpremisespublishingprofiles/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/onpremisespublishingprofiles/{id}/agents": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/onpremisespublishingprofiles/{id}/agents/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/administrativeunits/delta": {},
+            "/oauth2permissiongrants/delta": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/onpremisespublishingprofiles/{id}/agentgroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/onpremisespublishingprofiles/{id}/hybridagentupdaterconfiguration": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/appcatalogs/teamsapps/{id}/appdefinitions": {},
+            "/me/invalidateallrefreshtokens": {},
+            "/onpremisespublishingprofiles/{id}/agentgroups/{id}/agents": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/onpremisespublishingprofiles/{id}/agents/{id}/agentgroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/policies/featurerolloutpolicies/{id}/appliesto": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/invalidateallrefreshtokens": {}
+          }
+        },
+        {
+          "methods": [
+            "PUT"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/applications/{id}/connectorgroup": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        }
+      ],
+      "ownerEmail": ""
+    }
+  }
+}

--- a/kibaliTests/ValidPermissions/User.json
+++ b/kibaliTests/ValidPermissions/User.json
@@ -1,0 +1,2793 @@
+{
+  "$schema": "https://microsoftgraph.github.io/msgraph-metadata/graph-permissions-schema.json",
+  "permissions": {
+    "User.Export.All": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Export user\u0027s data",
+          "adminDescription": "Allows the app to export data (e.g. customer content or system-generated logs), associated with any user in your company, when the app is used by a privileged user (e.g. a Company Administrator).",
+          "userDisplayName": "Export user\u0027s data",
+          "userDescription": "Allows the app to export data (e.g. customer content or system-generated logs), associated with any user in your company, when the app is used by a privileged user (e.g. a Company Administrator).",
+          "requiresAdminConsent": true
+        },
+        "Application": {
+          "adminDisplayName": "Export user\u0027s data",
+          "adminDescription": "Allows the app to export data (e.g. customer content or system-generated logs), associated with any user in your company, when the app is used by a privileged user (e.g. a Company Administrator).",
+          "requiresAdminConsent": true
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/datapolicyoperations/{id}": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/{id}/exportpersonaldata": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            }
+          }
+        }
+      ],
+      "ownerEmail": ""
+    },
+    "User.Invite.All": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Invite guest users to the organization",
+          "adminDescription": "Allows the app to invite guest users to the organization, on behalf of the signed-in user.",
+          "userDisplayName": "Invite guest users to the organization",
+          "userDescription": "Allows the app to invite guest users to the organization, on your behalf.",
+          "requiresAdminConsent": true
+        },
+        "Application": {
+          "adminDisplayName": "Invite guest users to the organization",
+          "adminDescription": "Allows the app to invite guest users to the organization, without a signed-in user.",
+          "requiresAdminConsent": true
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/invitations": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            }
+          }
+        }
+      ],
+      "ownerEmail": ""
+    },
+    "User.ManageIdentities.All": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Manage  user identities",
+          "adminDescription": "Allows the app to read, update and delete identities that are associated with a user\u0027s account that the signed-in user has access to. This controls the identities users can sign-in with.",
+          "userDisplayName": "Manage  user identities",
+          "userDescription": "Allows the app to read, update and delete identities that are associated with a user\u0027s account that you have access to. This controls the identities users can sign-in with.",
+          "requiresAdminConsent": true
+        },
+        "Application": {
+          "adminDisplayName": "Manage all users\u0027 identities",
+          "adminDescription": "Allows the app to read, update and delete identities that are associated with a user\u0027s account, without a signed in user. This controls the identities users can sign-in with.",
+          "requiresAdminConsent": true
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/{id}": {}
+          }
+        }
+      ],
+      "ownerEmail": ""
+    },
+    "User.Read": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Sign in and read user profile",
+          "adminDescription": "Allows users to sign-in to the app, and allows the app to read the profile of signed-in users. It also allows the app to read basic company information of signed-in users.",
+          "userDisplayName": "Sign you in and read your profile",
+          "userDescription": "Allows you to sign in to the app with your organizational account and let the app read your profile. It also allows the app to read basic company information.",
+          "requiresAdminConsent": false
+        },
+        "DelegatedPersonal": {
+          "adminDisplayName": "Sign in and read user profile",
+          "adminDescription": "Allows users to sign-in to the app, and allows the app to read the profile of signed-in users. It also allows the app to read basic company information of signed-in users.",
+          "userDisplayName": "Sign you in and read your profile",
+          "userDescription": "Allows you to sign in to the app with your organizational account and let the app read your profile. It also allows the app to read basic company information.",
+          "requiresAdminConsent": false
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/applications": {}
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/schemaextensions": {},
+            "/schemaextensions/{id}": {},
+            "/organization": {},
+            "/education/me/user": {},
+            "/education/users/{id}/user": {},
+            "/me/directreports": {},
+            "/me/memberof": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/ownedobjects": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/registereddevices": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/delta": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/memberof": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/ownedobjects": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/registereddevices": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/transitivememberof": {},
+            "/users/{id}/usagerights": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/drive": {},
+            "/me/drives": {},
+            "/organization/{id}/branding": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/organization/{id}/branding/localizations/{id}": {},
+            "/me/analytics/settings": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/settings/contactmergesuggestions": {},
+            "/me/settings/iteminsights": {},
+            "/organization/{id}/branding/localizations": {},
+            "/users/{id}/analytics/settings": {},
+            "/users/{id}/settings/contactmergesuggestions": {},
+            "/users/{id}/settings/iteminsights": {},
+            "/me/findmeetingtimes": {},
+            "/me/findroomlists": {},
+            "/me/findrooms": {},
+            "/me/memberof/{id}": {},
+            "/me/settings": {},
+            "/users/{id}/accountenabled": {},
+            "/users/{id}/agegroup": {},
+            "/users/{id}/assignedlicenses": {},
+            "/users/{id}/assignedplans": {},
+            "/users/{id}/businessphones": {},
+            "/users/{id}/city": {},
+            "/users/{id}/companyname": {},
+            "/users/{id}/consentprovidedforminor": {},
+            "/users/{id}/country": {},
+            "/users/{id}/createddatetime": {},
+            "/users/{id}/creationtype": {},
+            "/users/{id}/deleteddatetime": {},
+            "/users/{id}/department": {},
+            "/users/{id}/devicekeys": {},
+            "/users/{id}/employeeid": {},
+            "/users/{id}/externaluserstate": {},
+            "/users/{id}/externaluserstatechangedatetime": {},
+            "/users/{id}/faxnumber": {},
+            "/users/{id}/imaddresses": {},
+            "/users/{id}/isresourceaccount": {},
+            "/users/{id}/jobtitle": {},
+            "/users/{id}/legalagegroupclassification": {},
+            "/users/{id}/mailnickname": {},
+            "/users/{id}/memberof/{id}": {},
+            "/users/{id}/mobilephone": {},
+            "/users/{id}/officelocation": {},
+            "/users/{id}/onpremisesdistinguishedname": {},
+            "/users/{id}/onpremisesdomainname": {},
+            "/users/{id}/onpremisesextensionattributes": {},
+            "/users/{id}/onpremisesimmutableid": {},
+            "/users/{id}/onpremiseslastsyncdatetime": {},
+            "/users/{id}/onpremisesprovisioningerrors": {},
+            "/users/{id}/onpremisessamaccountname": {},
+            "/users/{id}/onpremisessecurityidentifier": {},
+            "/users/{id}/onpremisessyncenabled": {},
+            "/users/{id}/onpremisesuserprincipalname": {},
+            "/users/{id}/othermails": {},
+            "/users/{id}/passwordpolicies": {},
+            "/users/{id}/passwordprofile": {},
+            "/users/{id}/photo": {},
+            "/users/{id}/photos": {},
+            "/users/{id}/photos/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/postalcode": {},
+            "/users/{id}/preferreddatalocation": {},
+            "/users/{id}/provisionedplans": {},
+            "/users/{id}/proxyaddresses": {},
+            "/users/{id}/refreshtokensvalidfromdatetime": {},
+            "/users/{id}/showinaddresslist": {},
+            "/users/{id}/signinsessionsvalidfromdatetime": {},
+            "/users/{id}/state": {},
+            "/users/{id}/streetaddress": {},
+            "/users/{id}/usagelocation": {},
+            "/users/{id}/usertype": {},
+            "/me/exportpersonaldata": {},
+            "/me/extensions": {},
+            "/me/onenote": {},
+            "/me/outlook": {},
+            "/me/owneddevices": {},
+            "/me/photo": {},
+            "/me/photos": {},
+            "/me/photos/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/contacts/{id}/checkmemberobjects": {},
+            "/contacts/{id}/getmemberobjects": {},
+            "/devices/{id}/checkmemberobjects": {},
+            "/devices/{id}/getmemberobjects": {},
+            "/directoryobjects/{id}/checkmemberobjects": {},
+            "/directoryobjects/{id}/getmemberobjects": {},
+            "/groups/{id}/checkmemberobjects": {},
+            "/groups/{id}/getmemberobjects": {},
+            "/me/checkmemberobjects": {},
+            "/me/getmemberobjects": {},
+            "/serviceprincipals/{id}/checkmemberobjects": {},
+            "/serviceprincipals/{id}/getmemberobjects": {},
+            "/users/{id}/checkmemberobjects": {},
+            "/users/{id}/getmemberobjects": {}
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/createdobjects": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/licensedetails": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}": {},
+            "/users/{id}/createdobjects": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/licensedetails": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/outlook/supportedlanguages": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/outlook/supportedtimezones": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/outlook/supportedtimezones(timezonestandard={value})": {},
+            "/me/profile": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/account": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/account/{id}": {},
+            "/me/profile/addresses": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/addresses/{id}": {},
+            "/me/profile/anniversaries": {},
+            "/me/profile/anniversaries/{id}": {},
+            "/me/profile/awards": {},
+            "/me/profile/awards/{id}": {},
+            "/me/profile/certifications": {},
+            "/me/profile/certifications/{id}": {},
+            "/me/profile/educationalactivities": {},
+            "/me/profile/educationalactivities/{id}": {},
+            "/me/profile/emails": {},
+            "/me/profile/emails/{id}": {},
+            "/me/profile/interests": {},
+            "/me/profile/interests/{id}": {},
+            "/me/profile/languages": {},
+            "/me/profile/languages/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/names/{id}": {},
+            "/me/profile/notes": {},
+            "/me/profile/patents": {},
+            "/me/profile/patents/{id}": {},
+            "/me/profile/phones": {},
+            "/me/profile/phones/{id}": {},
+            "/me/profile/positions": {},
+            "/me/profile/positions/{id}": {},
+            "/me/profile/projects": {},
+            "/me/profile/projects/{id}": {},
+            "/me/profile/publications": {},
+            "/me/profile/publications/{id}": {},
+            "/me/profile/skills": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/skills/{id}": {},
+            "/me/profile/webaccounts": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/webaccounts/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/websites": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/websites/{id}": {},
+            "/me/responsibilities": {},
+            "/users/{id}/outlook/supportedlanguages": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/outlook/supportedtimezones": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/outlook/supportedtimezones(timezonestandard={value})": {},
+            "/users/{id}/profile": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/account": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/account/{id}": {},
+            "/users/{id}/profile/addresses": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/addresses/{id}": {},
+            "/users/{id}/profile/anniversaries": {},
+            "/users/{id}/profile/anniversaries/{id}": {},
+            "/users/{id}/profile/awards": {},
+            "/users/{id}/profile/awards/{id}": {},
+            "/users/{id}/profile/certifications": {},
+            "/users/{id}/profile/certifications/{id}": {},
+            "/users/{id}/profile/educationalactivities": {},
+            "/users/{id}/profile/educationalactivities/{id}": {},
+            "/users/{id}/profile/emails": {},
+            "/users/{id}/profile/emails/{id}": {},
+            "/users/{id}/profile/interests": {},
+            "/users/{id}/profile/interests/{id}": {},
+            "/users/{id}/profile/languages": {},
+            "/users/{id}/profile/languages/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/names/{id}": {},
+            "/users/{id}/profile/notes": {},
+            "/users/{id}/profile/patents": {},
+            "/users/{id}/profile/patents/{id}": {},
+            "/users/{id}/profile/phones": {},
+            "/users/{id}/profile/phones/{id}": {},
+            "/users/{id}/profile/positions": {},
+            "/users/{id}/profile/positions/{id}": {},
+            "/users/{id}/profile/projects": {},
+            "/users/{id}/profile/projects/{id}": {},
+            "/users/{id}/profile/publications": {},
+            "/users/{id}/profile/publications/{id}": {},
+            "/users/{id}/profile/skills": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/skills/{id}": {},
+            "/users/{id}/profile/webaccounts": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/webaccounts/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/websites": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/websites/{id}": {},
+            "/users/{id}/responsibilities": {}
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/{id}/transitivereports/$count": {},
+            "/settings/regionalandlanguagesettings": {}
+          }
+        },
+        {
+          "methods": [
+            "DELETE",
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/notes/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/responsibilities/{id}": {},
+            "/users/{id}/profile/notes/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/responsibilities/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/names": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/names": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/translateexchangeids": {},
+            "/users/{id}/translateexchangeids": {}
+          }
+        }
+      ],
+      "ownerEmail": ""
+    },
+    "User.Read.All": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Read all users\u0027 full profiles",
+          "adminDescription": "Allows the app to read the full set of profile properties, reports, and managers of other users in your organization, on behalf of the signed-in user.",
+          "userDisplayName": "Read all users\u0027 full profiles",
+          "userDescription": "Allows the app to read the full set of profile properties, reports, and managers of other users in your organization, on your behalf.",
+          "requiresAdminConsent": true
+        },
+        "Application": {
+          "adminDisplayName": "Read all users\u0027 full profiles",
+          "adminDescription": "Allows the app to read user profiles without a signed in user.",
+          "requiresAdminConsent": true
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/directory/deleteditems/microsoft.graph.application": {},
+            "/directory/deleteditems/microsoft.graph.group": {},
+            "/directory/deleteditems/microsoft.graph.serviceprincipal": {},
+            "/directory/deleteditems/microsoft.graph.user": {},
+            "/directory/deleteditems/{id}": {},
+            "/me": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/createdobjects": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/directreports": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/me/joinedteams": {},
+            "/me/licensedetails": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/manager": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/me/ownedobjects": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/registereddevices": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users": {},
+            "/users/delta": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}": {},
+            "/users/{id}/createdobjects": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/directreports": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/joinedteams": {},
+            "/users/{id}/licensedetails": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/manager": {},
+            "/users/{id}/owneddevices": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/ownedobjects": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/registereddevices": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/transitivereports/$count": {},
+            "/users/{id}/usagerights": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/datapolicyoperations/{id}": {},
+            "/settings/regionalandlanguagesettings": {},
+            "/me/findroomlists": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/findrooms": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/findrooms(roomlist={value})": {},
+            "/me/settings": {},
+            "/users/{id}/findroomlists": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/findrooms": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/findrooms(roomlist={value})": {},
+            "/users/{id}/settings": {}
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/contacts/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/contacts/{id}/checkmemberobjects": {},
+            "/contacts/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/contacts/{id}/getmemberobjects": {},
+            "/devices/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/devices/{id}/checkmemberobjects": {},
+            "/devices/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/devices/{id}/getmemberobjects": {},
+            "/directoryobjects/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/directoryobjects/{id}/checkmemberobjects": {},
+            "/directoryobjects/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/directoryobjects/{id}/getmemberobjects": {},
+            "/groups/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/groups/{id}/checkmemberobjects": {},
+            "/groups/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/groups/{id}/getmemberobjects": {},
+            "/me/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/checkmemberobjects": {},
+            "/me/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/getmemberobjects": {},
+            "/serviceprincipals/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/serviceprincipals/{id}/checkmemberobjects": {},
+            "/serviceprincipals/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/serviceprincipals/{id}/getmemberobjects": {},
+            "/users/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/checkmemberobjects": {},
+            "/users/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/getmemberobjects": {},
+            "/me/translateexchangeids": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/translateexchangeids": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/organization/{id}/branding": {},
+            "/organization/{id}/branding/localizations/{id}": {},
+            "/organization/{id}/branding/localizations": {},
+            "/organization/{id}/settings/iteminsights": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/organization/{id}/settings/peopleinsights": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/settings/shiftpreferences": {}
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/groups/evaluatedynamicmembership": {},
+            "/groups/{id}/evaluatedynamicmembership": {}
+          }
+        },
+        {
+          "methods": [
+            "DELETE",
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/notes/{id}": {},
+            "/me/responsibilities/{id}": {},
+            "/users/{id}/profile/notes/{id}": {},
+            "/users/{id}/responsibilities/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "Application"
+          ],
+          "paths": {
+            "/me/memberof/{id}": {},
+            "/me/outlook/supportedlanguages": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/outlook/supportedtimezones": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/outlook/supportedtimezones(timezonestandard={value})": {},
+            "/users/{id}/accountenabled": {},
+            "/users/{id}/agegroup": {},
+            "/users/{id}/assignedlicenses": {},
+            "/users/{id}/assignedplans": {},
+            "/users/{id}/businessphones": {},
+            "/users/{id}/city": {},
+            "/users/{id}/companyname": {},
+            "/users/{id}/consentprovidedforminor": {},
+            "/users/{id}/country": {},
+            "/users/{id}/createddatetime": {},
+            "/users/{id}/creationtype": {},
+            "/users/{id}/deleteddatetime": {},
+            "/users/{id}/department": {},
+            "/users/{id}/devicekeys": {},
+            "/users/{id}/displayname": {},
+            "/users/{id}/employeeid": {},
+            "/users/{id}/externaluserstate": {},
+            "/users/{id}/externaluserstatechangedatetime": {},
+            "/users/{id}/faxnumber": {},
+            "/users/{id}/givenname": {},
+            "/users/{id}/id": {},
+            "/users/{id}/identities": {},
+            "/users/{id}/imaddresses": {},
+            "/users/{id}/isresourceaccount": {},
+            "/users/{id}/jobtitle": {},
+            "/users/{id}/legalagegroupclassification": {},
+            "/users/{id}/mail": {},
+            "/users/{id}/mailnickname": {},
+            "/users/{id}/memberof/{id}": {},
+            "/users/{id}/mobilephone": {},
+            "/users/{id}/officelocation": {},
+            "/users/{id}/onpremisesdistinguishedname": {},
+            "/users/{id}/onpremisesdomainname": {},
+            "/users/{id}/onpremisesextensionattributes": {},
+            "/users/{id}/onpremisesimmutableid": {},
+            "/users/{id}/onpremiseslastsyncdatetime": {},
+            "/users/{id}/onpremisesprovisioningerrors": {},
+            "/users/{id}/onpremisessamaccountname": {},
+            "/users/{id}/onpremisessecurityidentifier": {},
+            "/users/{id}/onpremisessyncenabled": {},
+            "/users/{id}/onpremisesuserprincipalname": {},
+            "/users/{id}/othermails": {},
+            "/users/{id}/outlook/supportedlanguages": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/outlook/supportedtimezones": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/outlook/supportedtimezones(timezonestandard={value})": {},
+            "/users/{id}/passwordpolicies": {},
+            "/users/{id}/passwordprofile": {},
+            "/users/{id}/photo": {},
+            "/users/{id}/photos": {},
+            "/users/{id}/photos/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/postalcode": {},
+            "/users/{id}/preferreddatalocation": {},
+            "/users/{id}/provisionedplans": {},
+            "/users/{id}/proxyaddresses": {},
+            "/users/{id}/refreshtokensvalidfromdatetime": {},
+            "/users/{id}/showinaddresslist": {},
+            "/users/{id}/signinsessionsvalidfromdatetime": {},
+            "/users/{id}/state": {},
+            "/users/{id}/streetaddress": {},
+            "/users/{id}/surname": {},
+            "/users/{id}/usagelocation": {},
+            "/users/{id}/userprincipalname": {},
+            "/users/{id}/usertype": {}
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile": {},
+            "/me/profile/account": {},
+            "/me/profile/account/{id}": {},
+            "/me/profile/addresses": {},
+            "/me/profile/addresses/{id}": {},
+            "/me/profile/anniversaries": {},
+            "/me/profile/anniversaries/{id}": {},
+            "/me/profile/awards": {},
+            "/me/profile/awards/{id}": {},
+            "/me/profile/certifications": {},
+            "/me/profile/certifications/{id}": {},
+            "/me/profile/educationalactivities": {},
+            "/me/profile/educationalactivities/{id}": {},
+            "/me/profile/emails": {},
+            "/me/profile/emails/{id}": {},
+            "/me/profile/interests": {},
+            "/me/profile/interests/{id}": {},
+            "/me/profile/languages": {},
+            "/me/profile/languages/{id}": {},
+            "/me/profile/names/{id}": {},
+            "/me/profile/notes": {},
+            "/me/profile/patents": {},
+            "/me/profile/patents/{id}": {},
+            "/me/profile/phones": {},
+            "/me/profile/phones/{id}": {},
+            "/me/profile/positions": {},
+            "/me/profile/positions/{id}": {},
+            "/me/profile/projects": {},
+            "/me/profile/projects/{id}": {},
+            "/me/profile/publications": {},
+            "/me/profile/publications/{id}": {},
+            "/me/profile/skills": {},
+            "/me/profile/skills/{id}": {},
+            "/me/profile/webaccounts": {},
+            "/me/profile/webaccounts/{id}": {},
+            "/me/profile/websites": {},
+            "/me/profile/websites/{id}": {},
+            "/me/responsibilities": {},
+            "/users/{id}/profile": {},
+            "/users/{id}/profile/account": {},
+            "/users/{id}/profile/account/{id}": {},
+            "/users/{id}/profile/addresses": {},
+            "/users/{id}/profile/addresses/{id}": {},
+            "/users/{id}/profile/anniversaries": {},
+            "/users/{id}/profile/anniversaries/{id}": {},
+            "/users/{id}/profile/awards": {},
+            "/users/{id}/profile/awards/{id}": {},
+            "/users/{id}/profile/certifications": {},
+            "/users/{id}/profile/certifications/{id}": {},
+            "/users/{id}/profile/educationalactivities": {},
+            "/users/{id}/profile/educationalactivities/{id}": {},
+            "/users/{id}/profile/emails": {},
+            "/users/{id}/profile/emails/{id}": {},
+            "/users/{id}/profile/interests": {},
+            "/users/{id}/profile/interests/{id}": {},
+            "/users/{id}/profile/languages": {},
+            "/users/{id}/profile/languages/{id}": {},
+            "/users/{id}/profile/names/{id}": {},
+            "/users/{id}/profile/notes": {},
+            "/users/{id}/profile/patents": {},
+            "/users/{id}/profile/patents/{id}": {},
+            "/users/{id}/profile/phones": {},
+            "/users/{id}/profile/phones/{id}": {},
+            "/users/{id}/profile/positions": {},
+            "/users/{id}/profile/positions/{id}": {},
+            "/users/{id}/profile/projects": {},
+            "/users/{id}/profile/projects/{id}": {},
+            "/users/{id}/profile/publications": {},
+            "/users/{id}/profile/publications/{id}": {},
+            "/users/{id}/profile/skills": {},
+            "/users/{id}/profile/skills/{id}": {},
+            "/users/{id}/profile/webaccounts": {},
+            "/users/{id}/profile/webaccounts/{id}": {},
+            "/users/{id}/profile/websites": {},
+            "/users/{id}/profile/websites/{id}": {},
+            "/users/{id}/responsibilities": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/names": {},
+            "/users/{id}/profile/names": {}
+          }
+        }
+      ],
+      "ownerEmail": ""
+    },
+    "User.ReadBasic.All": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Read all users\u0027 basic profiles",
+          "adminDescription": "Allows the app to read a basic set of profile properties of other users in your organization on behalf of the signed-in user. This includes display name, first and last name, email address and photo.",
+          "userDisplayName": "Read all users\u0027 basic profiles",
+          "userDescription": "Allows the app to read a basic set of profile properties of other users in your organization on your behalf. Includes display name, first and last name, email address and photo.",
+          "requiresAdminConsent": false
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/{id}/approleassignments": {},
+            "/me/oauth2permissiongrants": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/oauth2permissiongrants": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me": {},
+            "/users": {},
+            "/users/delta": {},
+            "/users/{id}": {},
+            "/organization/{id}/branding": {},
+            "/organization/{id}/branding/localizations/{id}": {},
+            "/organization/{id}/branding/localizations": {},
+            "/me/findroomlists": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/findrooms": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/findrooms(roomlist={value})": {},
+            "/me/outlook/supportedlanguages": {},
+            "/me/outlook/supportedtimezones": {},
+            "/me/outlook/supportedtimezones(timezonestandard={value})": {},
+            "/users/{id}/displayname": {},
+            "/users/{id}/findroomlists": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/findrooms": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/findrooms(roomlist={value})": {},
+            "/users/{id}/givenname": {},
+            "/users/{id}/id": {},
+            "/users/{id}/identities": {},
+            "/users/{id}/mail": {},
+            "/users/{id}/outlook/supportedlanguages": {},
+            "/users/{id}/outlook/supportedtimezones": {},
+            "/users/{id}/outlook/supportedtimezones(timezonestandard={value})": {},
+            "/users/{id}/surname": {},
+            "/users/{id}/userprincipalname": {},
+            "/me/accountenabled": {},
+            "/me/agegroup": {},
+            "/me/assignedlicenses": {},
+            "/me/assignedplans": {},
+            "/me/businessphones": {},
+            "/me/city": {},
+            "/me/companyname": {},
+            "/me/consentprovidedforminor": {},
+            "/me/country": {},
+            "/me/createddatetime": {},
+            "/me/creationtype": {},
+            "/me/deleteddatetime": {},
+            "/me/department": {},
+            "/me/devicekeys": {},
+            "/me/displayname": {},
+            "/me/employeeid": {},
+            "/me/externaluserstate": {},
+            "/me/externaluserstatechangedatetime": {},
+            "/me/faxnumber": {},
+            "/me/givenname": {},
+            "/me/id": {},
+            "/me/identities": {},
+            "/me/imaddresses": {},
+            "/me/isresourceaccount": {},
+            "/me/jobtitle": {},
+            "/me/legalagegroupclassification": {},
+            "/me/mail": {},
+            "/me/mailnickname": {},
+            "/me/mobilephone": {},
+            "/me/officelocation": {},
+            "/me/onpremisesdistinguishedname": {},
+            "/me/onpremisesdomainname": {},
+            "/me/onpremisesextensionattributes": {},
+            "/me/onpremisesimmutableid": {},
+            "/me/onpremiseslastsyncdatetime": {},
+            "/me/onpremisesprovisioningerrors": {},
+            "/me/onpremisessamaccountname": {},
+            "/me/onpremisessecurityidentifier": {},
+            "/me/onpremisessyncenabled": {},
+            "/me/onpremisesuserprincipalname": {},
+            "/me/othermails": {},
+            "/me/passwordpolicies": {},
+            "/me/passwordprofile": {},
+            "/me/postalcode": {},
+            "/me/preferreddatalocation": {},
+            "/me/provisionedplans": {},
+            "/me/proxyaddresses": {},
+            "/me/refreshtokensvalidfromdatetime": {},
+            "/me/showinaddresslist": {},
+            "/me/signinsessionsvalidfromdatetime": {},
+            "/me/state": {},
+            "/me/streetaddress": {},
+            "/me/surname": {},
+            "/me/usagelocation": {},
+            "/me/userprincipalname": {},
+            "/me/usertype": {}
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/contacts/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/contacts/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/devices/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/devices/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/directoryobjects/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/directoryobjects/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/groups/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/groups/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE",
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/notes/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/responsibilities/{id}": {},
+            "/users/{id}/profile/notes/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/responsibilities/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/account": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/account/{id}": {},
+            "/me/profile/addresses": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/addresses/{id}": {},
+            "/me/profile/anniversaries": {},
+            "/me/profile/anniversaries/{id}": {},
+            "/me/profile/awards": {},
+            "/me/profile/awards/{id}": {},
+            "/me/profile/certifications": {},
+            "/me/profile/certifications/{id}": {},
+            "/me/profile/educationalactivities": {},
+            "/me/profile/educationalactivities/{id}": {},
+            "/me/profile/emails": {},
+            "/me/profile/emails/{id}": {},
+            "/me/profile/interests": {},
+            "/me/profile/interests/{id}": {},
+            "/me/profile/languages": {},
+            "/me/profile/languages/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/names/{id}": {},
+            "/me/profile/notes": {},
+            "/me/profile/patents": {},
+            "/me/profile/patents/{id}": {},
+            "/me/profile/phones": {},
+            "/me/profile/phones/{id}": {},
+            "/me/profile/positions": {},
+            "/me/profile/positions/{id}": {},
+            "/me/profile/projects": {},
+            "/me/profile/projects/{id}": {},
+            "/me/profile/publications": {},
+            "/me/profile/publications/{id}": {},
+            "/me/profile/skills": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/skills/{id}": {},
+            "/me/profile/webaccounts": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/webaccounts/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/websites": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/websites/{id}": {},
+            "/me/responsibilities": {},
+            "/users/{id}/profile": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/account": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/account/{id}": {},
+            "/users/{id}/profile/addresses": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/addresses/{id}": {},
+            "/users/{id}/profile/anniversaries": {},
+            "/users/{id}/profile/anniversaries/{id}": {},
+            "/users/{id}/profile/awards": {},
+            "/users/{id}/profile/awards/{id}": {},
+            "/users/{id}/profile/certifications": {},
+            "/users/{id}/profile/certifications/{id}": {},
+            "/users/{id}/profile/educationalactivities": {},
+            "/users/{id}/profile/educationalactivities/{id}": {},
+            "/users/{id}/profile/emails": {},
+            "/users/{id}/profile/emails/{id}": {},
+            "/users/{id}/profile/interests": {},
+            "/users/{id}/profile/interests/{id}": {},
+            "/users/{id}/profile/languages": {},
+            "/users/{id}/profile/languages/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/names/{id}": {},
+            "/users/{id}/profile/notes": {},
+            "/users/{id}/profile/patents": {},
+            "/users/{id}/profile/patents/{id}": {},
+            "/users/{id}/profile/phones": {},
+            "/users/{id}/profile/phones/{id}": {},
+            "/users/{id}/profile/positions": {},
+            "/users/{id}/profile/positions/{id}": {},
+            "/users/{id}/profile/projects": {},
+            "/users/{id}/profile/projects/{id}": {},
+            "/users/{id}/profile/publications": {},
+            "/users/{id}/profile/publications/{id}": {},
+            "/users/{id}/profile/skills": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/skills/{id}": {},
+            "/users/{id}/profile/webaccounts": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/webaccounts/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/websites": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/websites/{id}": {},
+            "/users/{id}/responsibilities": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/names": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/names": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/translateexchangeids": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/translateexchangeids": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            }
+          }
+        }
+      ],
+      "ownerEmail": ""
+    },
+    "User.ReadWrite": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Read and write access to user profile",
+          "adminDescription": "Allows the app to read your profile. It also allows the app to update your profile information on your behalf.",
+          "userDisplayName": "Read and update your profile",
+          "userDescription": "Allows the app to read your profile, and discover your group membership, reports and manager. It also allows the app to update your profile information on your behalf.",
+          "requiresAdminConsent": false
+        },
+        "DelegatedPersonal": {
+          "adminDisplayName": "Read and write access to user profile",
+          "adminDescription": "Allows the app to read your profile. It also allows the app to update your profile information on your behalf.",
+          "userDisplayName": "Read and update your profile",
+          "userDescription": "Allows the app to read your profile, and discover your group membership, reports and manager. It also allows the app to update your profile information on your behalf.",
+          "requiresAdminConsent": false
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me": {},
+            "/me/createdobjects": {},
+            "/users/{id}/createdobjects": {}
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/delta": {},
+            "/users/{id}/usagerights": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/users/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/me/settings/contactmergesuggestions": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/settings/iteminsights": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/settings/contactmergesuggestions": {},
+            "/users/{id}/settings/iteminsights": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/me/invalidateallrefreshtokens": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/validatepassword": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/invalidateallrefreshtokens": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "PATCH",
+            "PUT"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/settings/regionalandlanguagesettings": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE",
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/notes/{id}": {},
+            "/me/responsibilities/{id}": {},
+            "/users/{id}/profile/notes/{id}": {},
+            "/users/{id}/responsibilities/{id}": {},
+            "/me/profile/account/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/addresses/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/anniversaries/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/awards/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/certifications/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/educationalactivities/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/emails/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/interests/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/languages/{id}": {},
+            "/me/profile/names/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/patents/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/phones/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/positions/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/projects/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/publications/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/skills/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/webaccounts/{id}": {},
+            "/me/profile/websites/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/account/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/addresses/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/anniversaries/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/awards/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/certifications/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/educationalactivities/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/emails/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/interests/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/languages/{id}": {},
+            "/users/{id}/profile/names/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/patents/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/phones/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/positions/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/projects/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/publications/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/skills/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/webaccounts/{id}": {},
+            "/users/{id}/profile/websites/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "DELETE"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile": {},
+            "/users/{id}/profile": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/account": {},
+            "/me/profile/addresses": {},
+            "/me/profile/anniversaries": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/awards": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/certifications": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/educationalactivities": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/emails": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/interests": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/languages": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/names": {},
+            "/me/profile/notes": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/patents": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/phones": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/positions": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/projects": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/publications": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/skills": {},
+            "/me/profile/webaccounts": {},
+            "/me/profile/websites": {},
+            "/me/responsibilities": {},
+            "/users/{id}/profile/account": {},
+            "/users/{id}/profile/addresses": {},
+            "/users/{id}/profile/anniversaries": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/awards": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/certifications": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/educationalactivities": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/emails": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/interests": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/languages": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/names": {},
+            "/users/{id}/profile/notes": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/patents": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/phones": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/positions": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/projects": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/publications": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/skills": {},
+            "/users/{id}/profile/webaccounts": {},
+            "/users/{id}/profile/websites": {},
+            "/users/{id}/responsibilities": {}
+          }
+        },
+        {
+          "methods": [
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/me/settings": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/settings": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "PATCH",
+            "PUT"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/{id}/photo": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/photo": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/translateexchangeids": {},
+            "/users/{id}/translateexchangeids": {}
+          }
+        }
+      ],
+      "ownerEmail": ""
+    },
+    "User.ReadWrite.All": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Read and write all users\u0027 full profiles",
+          "adminDescription": "Allows the app to read and write the full set of profile properties, reports, and managers of other users in your organization, on behalf of the signed-in user.",
+          "userDisplayName": "Read and write all users\u0027 full profiles",
+          "userDescription": "Allows the app to read and write the full set of profile properties, reports, and managers of other users in your organization, on your behalf.",
+          "requiresAdminConsent": true
+        },
+        "Application": {
+          "adminDisplayName": "Read and write all users\u0027 full profiles",
+          "adminDescription": "Allows the app to read and update user profiles without a signed in user.",
+          "requiresAdminConsent": true
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/directory/deleteditems/microsoft.graph.application": {},
+            "/directory/deleteditems/microsoft.graph.group": {},
+            "/directory/deleteditems/microsoft.graph.serviceprincipal": {},
+            "/directory/deleteditems/microsoft.graph.user": {},
+            "/me": {},
+            "/me/createdobjects": {},
+            "/me/directreports": {},
+            "/me/joinedteams": {},
+            "/me/licensedetails": {},
+            "/me/manager": {},
+            "/me/ownedobjects": {},
+            "/me/registereddevices": {},
+            "/users/delta": {},
+            "/users/{id}/createdobjects": {},
+            "/users/{id}/directreports": {},
+            "/users/{id}/joinedteams": {},
+            "/users/{id}/licensedetails": {},
+            "/users/{id}/owneddevices": {},
+            "/users/{id}/ownedobjects": {},
+            "/users/{id}/registereddevices": {},
+            "/users/{id}/usagerights": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "DELETE"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/directory/deleteditems/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/contacts/{id}/checkmembergroups": {},
+            "/contacts/{id}/checkmemberobjects": {},
+            "/contacts/{id}/getmemberobjects": {},
+            "/devices/{id}/checkmembergroups": {},
+            "/devices/{id}/checkmemberobjects": {},
+            "/devices/{id}/getmemberobjects": {},
+            "/directoryobjects/{id}/checkmembergroups": {},
+            "/directoryobjects/{id}/checkmemberobjects": {},
+            "/directoryobjects/{id}/getmemberobjects": {},
+            "/groups/{id}/checkmembergroups": {},
+            "/groups/{id}/checkmemberobjects": {},
+            "/groups/{id}/getmemberobjects": {},
+            "/me/checkmembergroups": {},
+            "/me/checkmemberobjects": {},
+            "/me/getmemberobjects": {},
+            "/serviceprincipals/{id}/checkmembergroups": {},
+            "/serviceprincipals/{id}/checkmemberobjects": {},
+            "/serviceprincipals/{id}/getmemberobjects": {},
+            "/users/{id}/checkmembergroups": {},
+            "/users/{id}/checkmemberobjects": {},
+            "/users/{id}/getmemberobjects": {},
+            "/directory/deleteditems/{id}/restore": {},
+            "/invitations": {},
+            "/me/revokesigninsessions": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/assignlicense": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/reprocesslicenseassignment": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/revokesigninsessions": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/me/translateexchangeids": {},
+            "/users/{id}/translateexchangeids": {}
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/directoryobjects/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "PATCH",
+            "DELETE"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "PUT"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/{id}/manager": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/organization/{id}/settings/iteminsights": {},
+            "/organization/{id}/settings/peopleinsights": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "PUT"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/{id}/settings/shiftpreferences": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/validatepassword": {}
+          }
+        },
+        {
+          "methods": [
+            "PATCH",
+            "PUT"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/settings/regionalandlanguagesettings": {}
+          }
+        },
+        {
+          "methods": [
+            "DELETE",
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/notes/{id}": {},
+            "/me/responsibilities/{id}": {},
+            "/users/{id}/profile/notes/{id}": {},
+            "/users/{id}/responsibilities/{id}": {},
+            "/me/profile/account/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/addresses/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/anniversaries/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/awards/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/certifications/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/educationalactivities/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/emails/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/interests/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/languages/{id}": {},
+            "/me/profile/names/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/patents/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/phones/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/positions/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/projects/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/publications/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/skills/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/webaccounts/{id}": {},
+            "/me/profile/websites/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/account/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/addresses/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/anniversaries/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/awards/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/certifications/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/educationalactivities/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/emails/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/interests/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/languages/{id}": {},
+            "/users/{id}/profile/names/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/patents/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/phones/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/positions/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/projects/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/publications/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/skills/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/webaccounts/{id}": {},
+            "/users/{id}/profile/websites/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "DELETE"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile": {},
+            "/users/{id}/profile": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/account": {},
+            "/me/profile/addresses": {},
+            "/me/profile/anniversaries": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/awards": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/certifications": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/educationalactivities": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/emails": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/interests": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/languages": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/names": {},
+            "/me/profile/notes": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/patents": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/phones": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/positions": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/projects": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/publications": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/skills": {},
+            "/me/profile/webaccounts": {},
+            "/me/profile/websites": {},
+            "/me/responsibilities": {},
+            "/users/{id}/profile/account": {},
+            "/users/{id}/profile/addresses": {},
+            "/users/{id}/profile/anniversaries": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/awards": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/certifications": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/educationalactivities": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/emails": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/interests": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/languages": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/names": {},
+            "/users/{id}/profile/notes": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/patents": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/phones": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/positions": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/projects": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/publications": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/skills": {},
+            "/users/{id}/profile/webaccounts": {},
+            "/users/{id}/profile/websites": {},
+            "/users/{id}/responsibilities": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/me/settings": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/settings": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "PATCH",
+            "PUT"
+          ],
+          "schemeKeys": [
+            "Application"
+          ],
+          "paths": {
+            "/users/{id}/photo": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            }
+          }
+        }
+      ],
+      "ownerEmail": ""
+    }
+  }
+}

--- a/kibaliTests/ValidUser.json
+++ b/kibaliTests/ValidUser.json
@@ -1,0 +1,2793 @@
+{
+  "$schema": "https://microsoftgraph.github.io/msgraph-metadata/graph-permissions-schema.json",
+  "permissions": {
+    "User.Export.All": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Export user\u0027s data",
+          "adminDescription": "Allows the app to export data (e.g. customer content or system-generated logs), associated with any user in your company, when the app is used by a privileged user (e.g. a Company Administrator).",
+          "userDisplayName": "Export user\u0027s data",
+          "userDescription": "Allows the app to export data (e.g. customer content or system-generated logs), associated with any user in your company, when the app is used by a privileged user (e.g. a Company Administrator).",
+          "requiresAdminConsent": true
+        },
+        "Application": {
+          "adminDisplayName": "Export user\u0027s data",
+          "adminDescription": "Allows the app to export data (e.g. customer content or system-generated logs), associated with any user in your company, when the app is used by a privileged user (e.g. a Company Administrator).",
+          "requiresAdminConsent": true
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/datapolicyoperations/{id}": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/{id}/exportpersonaldata": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            }
+          }
+        }
+      ],
+      "ownerEmail": ""
+    },
+    "User.Invite.All": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Invite guest users to the organization",
+          "adminDescription": "Allows the app to invite guest users to the organization, on behalf of the signed-in user.",
+          "userDisplayName": "Invite guest users to the organization",
+          "userDescription": "Allows the app to invite guest users to the organization, on your behalf.",
+          "requiresAdminConsent": true
+        },
+        "Application": {
+          "adminDisplayName": "Invite guest users to the organization",
+          "adminDescription": "Allows the app to invite guest users to the organization, without a signed-in user.",
+          "requiresAdminConsent": true
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/invitations": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            }
+          }
+        }
+      ],
+      "ownerEmail": ""
+    },
+    "User.ManageIdentities.All": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Manage  user identities",
+          "adminDescription": "Allows the app to read, update and delete identities that are associated with a user\u0027s account that the signed-in user has access to. This controls the identities users can sign-in with.",
+          "userDisplayName": "Manage  user identities",
+          "userDescription": "Allows the app to read, update and delete identities that are associated with a user\u0027s account that you have access to. This controls the identities users can sign-in with.",
+          "requiresAdminConsent": true
+        },
+        "Application": {
+          "adminDisplayName": "Manage all users\u0027 identities",
+          "adminDescription": "Allows the app to read, update and delete identities that are associated with a user\u0027s account, without a signed in user. This controls the identities users can sign-in with.",
+          "requiresAdminConsent": true
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/{id}": {}
+          }
+        }
+      ],
+      "ownerEmail": ""
+    },
+    "User.Read": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Sign in and read user profile",
+          "adminDescription": "Allows users to sign-in to the app, and allows the app to read the profile of signed-in users. It also allows the app to read basic company information of signed-in users.",
+          "userDisplayName": "Sign you in and read your profile",
+          "userDescription": "Allows you to sign in to the app with your organizational account and let the app read your profile. It also allows the app to read basic company information.",
+          "requiresAdminConsent": false
+        },
+        "DelegatedPersonal": {
+          "adminDisplayName": "Sign in and read user profile",
+          "adminDescription": "Allows users to sign-in to the app, and allows the app to read the profile of signed-in users. It also allows the app to read basic company information of signed-in users.",
+          "userDisplayName": "Sign you in and read your profile",
+          "userDescription": "Allows you to sign in to the app with your organizational account and let the app read your profile. It also allows the app to read basic company information.",
+          "requiresAdminConsent": false
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/applications": {}
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/schemaextensions": {},
+            "/schemaextensions/{id}": {},
+            "/organization": {},
+            "/education/me/user": {},
+            "/education/users/{id}/user": {},
+            "/me/directreports": {},
+            "/me/memberof": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/ownedobjects": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/registereddevices": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/delta": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/memberof": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/ownedobjects": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/registereddevices": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/transitivememberof": {},
+            "/users/{id}/usagerights": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/drive": {},
+            "/me/drives": {},
+            "/organization/{id}/branding": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/organization/{id}/branding/localizations/{id}": {},
+            "/me/analytics/settings": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/settings/contactmergesuggestions": {},
+            "/me/settings/iteminsights": {},
+            "/organization/{id}/branding/localizations": {},
+            "/users/{id}/analytics/settings": {},
+            "/users/{id}/settings/contactmergesuggestions": {},
+            "/users/{id}/settings/iteminsights": {},
+            "/me/findmeetingtimes": {},
+            "/me/findroomlists": {},
+            "/me/findrooms": {},
+            "/me/memberof/{id}": {},
+            "/me/settings": {},
+            "/users/{id}/accountenabled": {},
+            "/users/{id}/agegroup": {},
+            "/users/{id}/assignedlicenses": {},
+            "/users/{id}/assignedplans": {},
+            "/users/{id}/businessphones": {},
+            "/users/{id}/city": {},
+            "/users/{id}/companyname": {},
+            "/users/{id}/consentprovidedforminor": {},
+            "/users/{id}/country": {},
+            "/users/{id}/createddatetime": {},
+            "/users/{id}/creationtype": {},
+            "/users/{id}/deleteddatetime": {},
+            "/users/{id}/department": {},
+            "/users/{id}/devicekeys": {},
+            "/users/{id}/employeeid": {},
+            "/users/{id}/externaluserstate": {},
+            "/users/{id}/externaluserstatechangedatetime": {},
+            "/users/{id}/faxnumber": {},
+            "/users/{id}/imaddresses": {},
+            "/users/{id}/isresourceaccount": {},
+            "/users/{id}/jobtitle": {},
+            "/users/{id}/legalagegroupclassification": {},
+            "/users/{id}/mailnickname": {},
+            "/users/{id}/memberof/{id}": {},
+            "/users/{id}/mobilephone": {},
+            "/users/{id}/officelocation": {},
+            "/users/{id}/onpremisesdistinguishedname": {},
+            "/users/{id}/onpremisesdomainname": {},
+            "/users/{id}/onpremisesextensionattributes": {},
+            "/users/{id}/onpremisesimmutableid": {},
+            "/users/{id}/onpremiseslastsyncdatetime": {},
+            "/users/{id}/onpremisesprovisioningerrors": {},
+            "/users/{id}/onpremisessamaccountname": {},
+            "/users/{id}/onpremisessecurityidentifier": {},
+            "/users/{id}/onpremisessyncenabled": {},
+            "/users/{id}/onpremisesuserprincipalname": {},
+            "/users/{id}/othermails": {},
+            "/users/{id}/passwordpolicies": {},
+            "/users/{id}/passwordprofile": {},
+            "/users/{id}/photo": {},
+            "/users/{id}/photos": {},
+            "/users/{id}/photos/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/postalcode": {},
+            "/users/{id}/preferreddatalocation": {},
+            "/users/{id}/provisionedplans": {},
+            "/users/{id}/proxyaddresses": {},
+            "/users/{id}/refreshtokensvalidfromdatetime": {},
+            "/users/{id}/showinaddresslist": {},
+            "/users/{id}/signinsessionsvalidfromdatetime": {},
+            "/users/{id}/state": {},
+            "/users/{id}/streetaddress": {},
+            "/users/{id}/usagelocation": {},
+            "/users/{id}/usertype": {},
+            "/me/exportpersonaldata": {},
+            "/me/extensions": {},
+            "/me/onenote": {},
+            "/me/outlook": {},
+            "/me/owneddevices": {},
+            "/me/photo": {},
+            "/me/photos": {},
+            "/me/photos/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/contacts/{id}/checkmemberobjects": {},
+            "/contacts/{id}/getmemberobjects": {},
+            "/devices/{id}/checkmemberobjects": {},
+            "/devices/{id}/getmemberobjects": {},
+            "/directoryobjects/{id}/checkmemberobjects": {},
+            "/directoryobjects/{id}/getmemberobjects": {},
+            "/groups/{id}/checkmemberobjects": {},
+            "/groups/{id}/getmemberobjects": {},
+            "/me/checkmemberobjects": {},
+            "/me/getmemberobjects": {},
+            "/serviceprincipals/{id}/checkmemberobjects": {},
+            "/serviceprincipals/{id}/getmemberobjects": {},
+            "/users/{id}/checkmemberobjects": {},
+            "/users/{id}/getmemberobjects": {}
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/createdobjects": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/licensedetails": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}": {},
+            "/users/{id}/createdobjects": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/licensedetails": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/outlook/supportedlanguages": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/outlook/supportedtimezones": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/outlook/supportedtimezones(timezonestandard={value})": {},
+            "/me/profile": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/account": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/account/{id}": {},
+            "/me/profile/addresses": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/addresses/{id}": {},
+            "/me/profile/anniversaries": {},
+            "/me/profile/anniversaries/{id}": {},
+            "/me/profile/awards": {},
+            "/me/profile/awards/{id}": {},
+            "/me/profile/certifications": {},
+            "/me/profile/certifications/{id}": {},
+            "/me/profile/educationalactivities": {},
+            "/me/profile/educationalactivities/{id}": {},
+            "/me/profile/emails": {},
+            "/me/profile/emails/{id}": {},
+            "/me/profile/interests": {},
+            "/me/profile/interests/{id}": {},
+            "/me/profile/languages": {},
+            "/me/profile/languages/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/names/{id}": {},
+            "/me/profile/notes": {},
+            "/me/profile/patents": {},
+            "/me/profile/patents/{id}": {},
+            "/me/profile/phones": {},
+            "/me/profile/phones/{id}": {},
+            "/me/profile/positions": {},
+            "/me/profile/positions/{id}": {},
+            "/me/profile/projects": {},
+            "/me/profile/projects/{id}": {},
+            "/me/profile/publications": {},
+            "/me/profile/publications/{id}": {},
+            "/me/profile/skills": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/skills/{id}": {},
+            "/me/profile/webaccounts": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/webaccounts/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/websites": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/websites/{id}": {},
+            "/me/responsibilities": {},
+            "/users/{id}/outlook/supportedlanguages": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/outlook/supportedtimezones": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/outlook/supportedtimezones(timezonestandard={value})": {},
+            "/users/{id}/profile": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/account": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/account/{id}": {},
+            "/users/{id}/profile/addresses": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/addresses/{id}": {},
+            "/users/{id}/profile/anniversaries": {},
+            "/users/{id}/profile/anniversaries/{id}": {},
+            "/users/{id}/profile/awards": {},
+            "/users/{id}/profile/awards/{id}": {},
+            "/users/{id}/profile/certifications": {},
+            "/users/{id}/profile/certifications/{id}": {},
+            "/users/{id}/profile/educationalactivities": {},
+            "/users/{id}/profile/educationalactivities/{id}": {},
+            "/users/{id}/profile/emails": {},
+            "/users/{id}/profile/emails/{id}": {},
+            "/users/{id}/profile/interests": {},
+            "/users/{id}/profile/interests/{id}": {},
+            "/users/{id}/profile/languages": {},
+            "/users/{id}/profile/languages/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/names/{id}": {},
+            "/users/{id}/profile/notes": {},
+            "/users/{id}/profile/patents": {},
+            "/users/{id}/profile/patents/{id}": {},
+            "/users/{id}/profile/phones": {},
+            "/users/{id}/profile/phones/{id}": {},
+            "/users/{id}/profile/positions": {},
+            "/users/{id}/profile/positions/{id}": {},
+            "/users/{id}/profile/projects": {},
+            "/users/{id}/profile/projects/{id}": {},
+            "/users/{id}/profile/publications": {},
+            "/users/{id}/profile/publications/{id}": {},
+            "/users/{id}/profile/skills": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/skills/{id}": {},
+            "/users/{id}/profile/webaccounts": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/webaccounts/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/websites": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/websites/{id}": {},
+            "/users/{id}/responsibilities": {}
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/{id}/transitivereports/$count": {},
+            "/settings/regionalandlanguagesettings": {}
+          }
+        },
+        {
+          "methods": [
+            "DELETE",
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/notes/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/responsibilities/{id}": {},
+            "/users/{id}/profile/notes/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/responsibilities/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/names": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/names": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/translateexchangeids": {},
+            "/users/{id}/translateexchangeids": {}
+          }
+        }
+      ],
+      "ownerEmail": ""
+    },
+    "User.Read.All": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Read all users\u0027 full profiles",
+          "adminDescription": "Allows the app to read the full set of profile properties, reports, and managers of other users in your organization, on behalf of the signed-in user.",
+          "userDisplayName": "Read all users\u0027 full profiles",
+          "userDescription": "Allows the app to read the full set of profile properties, reports, and managers of other users in your organization, on your behalf.",
+          "requiresAdminConsent": true
+        },
+        "Application": {
+          "adminDisplayName": "Read all users\u0027 full profiles",
+          "adminDescription": "Allows the app to read user profiles without a signed in user.",
+          "requiresAdminConsent": true
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/directory/deleteditems/microsoft.graph.application": {},
+            "/directory/deleteditems/microsoft.graph.group": {},
+            "/directory/deleteditems/microsoft.graph.serviceprincipal": {},
+            "/directory/deleteditems/microsoft.graph.user": {},
+            "/directory/deleteditems/{id}": {},
+            "/me": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/createdobjects": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/directreports": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/me/joinedteams": {},
+            "/me/licensedetails": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/manager": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/me/ownedobjects": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/registereddevices": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users": {},
+            "/users/delta": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}": {},
+            "/users/{id}/createdobjects": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/directreports": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/joinedteams": {},
+            "/users/{id}/licensedetails": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/manager": {},
+            "/users/{id}/owneddevices": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/ownedobjects": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/registereddevices": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/transitivereports/$count": {},
+            "/users/{id}/usagerights": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/datapolicyoperations/{id}": {},
+            "/settings/regionalandlanguagesettings": {},
+            "/me/findroomlists": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/findrooms": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/findrooms(roomlist={value})": {},
+            "/me/settings": {},
+            "/users/{id}/findroomlists": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/findrooms": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/findrooms(roomlist={value})": {},
+            "/users/{id}/settings": {}
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/contacts/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/contacts/{id}/checkmemberobjects": {},
+            "/contacts/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/contacts/{id}/getmemberobjects": {},
+            "/devices/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/devices/{id}/checkmemberobjects": {},
+            "/devices/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/devices/{id}/getmemberobjects": {},
+            "/directoryobjects/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/directoryobjects/{id}/checkmemberobjects": {},
+            "/directoryobjects/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/directoryobjects/{id}/getmemberobjects": {},
+            "/groups/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/groups/{id}/checkmemberobjects": {},
+            "/groups/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/groups/{id}/getmemberobjects": {},
+            "/me/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/checkmemberobjects": {},
+            "/me/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/getmemberobjects": {},
+            "/serviceprincipals/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/serviceprincipals/{id}/checkmemberobjects": {},
+            "/serviceprincipals/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/serviceprincipals/{id}/getmemberobjects": {},
+            "/users/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/checkmemberobjects": {},
+            "/users/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/getmemberobjects": {},
+            "/me/translateexchangeids": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/translateexchangeids": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/organization/{id}/branding": {},
+            "/organization/{id}/branding/localizations/{id}": {},
+            "/organization/{id}/branding/localizations": {},
+            "/organization/{id}/settings/iteminsights": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/organization/{id}/settings/peopleinsights": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/settings/shiftpreferences": {}
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/groups/evaluatedynamicmembership": {},
+            "/groups/{id}/evaluatedynamicmembership": {}
+          }
+        },
+        {
+          "methods": [
+            "DELETE",
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/notes/{id}": {},
+            "/me/responsibilities/{id}": {},
+            "/users/{id}/profile/notes/{id}": {},
+            "/users/{id}/responsibilities/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "Application"
+          ],
+          "paths": {
+            "/me/memberof/{id}": {},
+            "/me/outlook/supportedlanguages": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/outlook/supportedtimezones": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/outlook/supportedtimezones(timezonestandard={value})": {},
+            "/users/{id}/accountenabled": {},
+            "/users/{id}/agegroup": {},
+            "/users/{id}/assignedlicenses": {},
+            "/users/{id}/assignedplans": {},
+            "/users/{id}/businessphones": {},
+            "/users/{id}/city": {},
+            "/users/{id}/companyname": {},
+            "/users/{id}/consentprovidedforminor": {},
+            "/users/{id}/country": {},
+            "/users/{id}/createddatetime": {},
+            "/users/{id}/creationtype": {},
+            "/users/{id}/deleteddatetime": {},
+            "/users/{id}/department": {},
+            "/users/{id}/devicekeys": {},
+            "/users/{id}/displayname": {},
+            "/users/{id}/employeeid": {},
+            "/users/{id}/externaluserstate": {},
+            "/users/{id}/externaluserstatechangedatetime": {},
+            "/users/{id}/faxnumber": {},
+            "/users/{id}/givenname": {},
+            "/users/{id}/id": {},
+            "/users/{id}/identities": {},
+            "/users/{id}/imaddresses": {},
+            "/users/{id}/isresourceaccount": {},
+            "/users/{id}/jobtitle": {},
+            "/users/{id}/legalagegroupclassification": {},
+            "/users/{id}/mail": {},
+            "/users/{id}/mailnickname": {},
+            "/users/{id}/memberof/{id}": {},
+            "/users/{id}/mobilephone": {},
+            "/users/{id}/officelocation": {},
+            "/users/{id}/onpremisesdistinguishedname": {},
+            "/users/{id}/onpremisesdomainname": {},
+            "/users/{id}/onpremisesextensionattributes": {},
+            "/users/{id}/onpremisesimmutableid": {},
+            "/users/{id}/onpremiseslastsyncdatetime": {},
+            "/users/{id}/onpremisesprovisioningerrors": {},
+            "/users/{id}/onpremisessamaccountname": {},
+            "/users/{id}/onpremisessecurityidentifier": {},
+            "/users/{id}/onpremisessyncenabled": {},
+            "/users/{id}/onpremisesuserprincipalname": {},
+            "/users/{id}/othermails": {},
+            "/users/{id}/outlook/supportedlanguages": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/outlook/supportedtimezones": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/outlook/supportedtimezones(timezonestandard={value})": {},
+            "/users/{id}/passwordpolicies": {},
+            "/users/{id}/passwordprofile": {},
+            "/users/{id}/photo": {},
+            "/users/{id}/photos": {},
+            "/users/{id}/photos/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/postalcode": {},
+            "/users/{id}/preferreddatalocation": {},
+            "/users/{id}/provisionedplans": {},
+            "/users/{id}/proxyaddresses": {},
+            "/users/{id}/refreshtokensvalidfromdatetime": {},
+            "/users/{id}/showinaddresslist": {},
+            "/users/{id}/signinsessionsvalidfromdatetime": {},
+            "/users/{id}/state": {},
+            "/users/{id}/streetaddress": {},
+            "/users/{id}/surname": {},
+            "/users/{id}/usagelocation": {},
+            "/users/{id}/userprincipalname": {},
+            "/users/{id}/usertype": {}
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile": {},
+            "/me/profile/account": {},
+            "/me/profile/account/{id}": {},
+            "/me/profile/addresses": {},
+            "/me/profile/addresses/{id}": {},
+            "/me/profile/anniversaries": {},
+            "/me/profile/anniversaries/{id}": {},
+            "/me/profile/awards": {},
+            "/me/profile/awards/{id}": {},
+            "/me/profile/certifications": {},
+            "/me/profile/certifications/{id}": {},
+            "/me/profile/educationalactivities": {},
+            "/me/profile/educationalactivities/{id}": {},
+            "/me/profile/emails": {},
+            "/me/profile/emails/{id}": {},
+            "/me/profile/interests": {},
+            "/me/profile/interests/{id}": {},
+            "/me/profile/languages": {},
+            "/me/profile/languages/{id}": {},
+            "/me/profile/names/{id}": {},
+            "/me/profile/notes": {},
+            "/me/profile/patents": {},
+            "/me/profile/patents/{id}": {},
+            "/me/profile/phones": {},
+            "/me/profile/phones/{id}": {},
+            "/me/profile/positions": {},
+            "/me/profile/positions/{id}": {},
+            "/me/profile/projects": {},
+            "/me/profile/projects/{id}": {},
+            "/me/profile/publications": {},
+            "/me/profile/publications/{id}": {},
+            "/me/profile/skills": {},
+            "/me/profile/skills/{id}": {},
+            "/me/profile/webaccounts": {},
+            "/me/profile/webaccounts/{id}": {},
+            "/me/profile/websites": {},
+            "/me/profile/websites/{id}": {},
+            "/me/responsibilities": {},
+            "/users/{id}/profile": {},
+            "/users/{id}/profile/account": {},
+            "/users/{id}/profile/account/{id}": {},
+            "/users/{id}/profile/addresses": {},
+            "/users/{id}/profile/addresses/{id}": {},
+            "/users/{id}/profile/anniversaries": {},
+            "/users/{id}/profile/anniversaries/{id}": {},
+            "/users/{id}/profile/awards": {},
+            "/users/{id}/profile/awards/{id}": {},
+            "/users/{id}/profile/certifications": {},
+            "/users/{id}/profile/certifications/{id}": {},
+            "/users/{id}/profile/educationalactivities": {},
+            "/users/{id}/profile/educationalactivities/{id}": {},
+            "/users/{id}/profile/emails": {},
+            "/users/{id}/profile/emails/{id}": {},
+            "/users/{id}/profile/interests": {},
+            "/users/{id}/profile/interests/{id}": {},
+            "/users/{id}/profile/languages": {},
+            "/users/{id}/profile/languages/{id}": {},
+            "/users/{id}/profile/names/{id}": {},
+            "/users/{id}/profile/notes": {},
+            "/users/{id}/profile/patents": {},
+            "/users/{id}/profile/patents/{id}": {},
+            "/users/{id}/profile/phones": {},
+            "/users/{id}/profile/phones/{id}": {},
+            "/users/{id}/profile/positions": {},
+            "/users/{id}/profile/positions/{id}": {},
+            "/users/{id}/profile/projects": {},
+            "/users/{id}/profile/projects/{id}": {},
+            "/users/{id}/profile/publications": {},
+            "/users/{id}/profile/publications/{id}": {},
+            "/users/{id}/profile/skills": {},
+            "/users/{id}/profile/skills/{id}": {},
+            "/users/{id}/profile/webaccounts": {},
+            "/users/{id}/profile/webaccounts/{id}": {},
+            "/users/{id}/profile/websites": {},
+            "/users/{id}/profile/websites/{id}": {},
+            "/users/{id}/responsibilities": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/names": {},
+            "/users/{id}/profile/names": {}
+          }
+        }
+      ],
+      "ownerEmail": ""
+    },
+    "User.ReadBasic.All": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Read all users\u0027 basic profiles",
+          "adminDescription": "Allows the app to read a basic set of profile properties of other users in your organization on behalf of the signed-in user. This includes display name, first and last name, email address and photo.",
+          "userDisplayName": "Read all users\u0027 basic profiles",
+          "userDescription": "Allows the app to read a basic set of profile properties of other users in your organization on your behalf. Includes display name, first and last name, email address and photo.",
+          "requiresAdminConsent": false
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/{id}/approleassignments": {},
+            "/me/oauth2permissiongrants": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/oauth2permissiongrants": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me": {},
+            "/users": {},
+            "/users/delta": {},
+            "/users/{id}": {},
+            "/organization/{id}/branding": {},
+            "/organization/{id}/branding/localizations/{id}": {},
+            "/organization/{id}/branding/localizations": {},
+            "/me/findroomlists": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/findrooms": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/findrooms(roomlist={value})": {},
+            "/me/outlook/supportedlanguages": {},
+            "/me/outlook/supportedtimezones": {},
+            "/me/outlook/supportedtimezones(timezonestandard={value})": {},
+            "/users/{id}/displayname": {},
+            "/users/{id}/findroomlists": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/findrooms": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/findrooms(roomlist={value})": {},
+            "/users/{id}/givenname": {},
+            "/users/{id}/id": {},
+            "/users/{id}/identities": {},
+            "/users/{id}/mail": {},
+            "/users/{id}/outlook/supportedlanguages": {},
+            "/users/{id}/outlook/supportedtimezones": {},
+            "/users/{id}/outlook/supportedtimezones(timezonestandard={value})": {},
+            "/users/{id}/surname": {},
+            "/users/{id}/userprincipalname": {},
+            "/me/accountenabled": {},
+            "/me/agegroup": {},
+            "/me/assignedlicenses": {},
+            "/me/assignedplans": {},
+            "/me/businessphones": {},
+            "/me/city": {},
+            "/me/companyname": {},
+            "/me/consentprovidedforminor": {},
+            "/me/country": {},
+            "/me/createddatetime": {},
+            "/me/creationtype": {},
+            "/me/deleteddatetime": {},
+            "/me/department": {},
+            "/me/devicekeys": {},
+            "/me/displayname": {},
+            "/me/employeeid": {},
+            "/me/externaluserstate": {},
+            "/me/externaluserstatechangedatetime": {},
+            "/me/faxnumber": {},
+            "/me/givenname": {},
+            "/me/id": {},
+            "/me/identities": {},
+            "/me/imaddresses": {},
+            "/me/isresourceaccount": {},
+            "/me/jobtitle": {},
+            "/me/legalagegroupclassification": {},
+            "/me/mail": {},
+            "/me/mailnickname": {},
+            "/me/mobilephone": {},
+            "/me/officelocation": {},
+            "/me/onpremisesdistinguishedname": {},
+            "/me/onpremisesdomainname": {},
+            "/me/onpremisesextensionattributes": {},
+            "/me/onpremisesimmutableid": {},
+            "/me/onpremiseslastsyncdatetime": {},
+            "/me/onpremisesprovisioningerrors": {},
+            "/me/onpremisessamaccountname": {},
+            "/me/onpremisessecurityidentifier": {},
+            "/me/onpremisessyncenabled": {},
+            "/me/onpremisesuserprincipalname": {},
+            "/me/othermails": {},
+            "/me/passwordpolicies": {},
+            "/me/passwordprofile": {},
+            "/me/postalcode": {},
+            "/me/preferreddatalocation": {},
+            "/me/provisionedplans": {},
+            "/me/proxyaddresses": {},
+            "/me/refreshtokensvalidfromdatetime": {},
+            "/me/showinaddresslist": {},
+            "/me/signinsessionsvalidfromdatetime": {},
+            "/me/state": {},
+            "/me/streetaddress": {},
+            "/me/surname": {},
+            "/me/usagelocation": {},
+            "/me/userprincipalname": {},
+            "/me/usertype": {}
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/contacts/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/contacts/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/devices/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/devices/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/directoryobjects/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/directoryobjects/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/groups/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/groups/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/serviceprincipals/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/checkmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/getmembergroups": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE",
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/notes/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/responsibilities/{id}": {},
+            "/users/{id}/profile/notes/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/responsibilities/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/account": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/account/{id}": {},
+            "/me/profile/addresses": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/addresses/{id}": {},
+            "/me/profile/anniversaries": {},
+            "/me/profile/anniversaries/{id}": {},
+            "/me/profile/awards": {},
+            "/me/profile/awards/{id}": {},
+            "/me/profile/certifications": {},
+            "/me/profile/certifications/{id}": {},
+            "/me/profile/educationalactivities": {},
+            "/me/profile/educationalactivities/{id}": {},
+            "/me/profile/emails": {},
+            "/me/profile/emails/{id}": {},
+            "/me/profile/interests": {},
+            "/me/profile/interests/{id}": {},
+            "/me/profile/languages": {},
+            "/me/profile/languages/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/names/{id}": {},
+            "/me/profile/notes": {},
+            "/me/profile/patents": {},
+            "/me/profile/patents/{id}": {},
+            "/me/profile/phones": {},
+            "/me/profile/phones/{id}": {},
+            "/me/profile/positions": {},
+            "/me/profile/positions/{id}": {},
+            "/me/profile/projects": {},
+            "/me/profile/projects/{id}": {},
+            "/me/profile/publications": {},
+            "/me/profile/publications/{id}": {},
+            "/me/profile/skills": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/skills/{id}": {},
+            "/me/profile/webaccounts": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/webaccounts/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/websites": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/websites/{id}": {},
+            "/me/responsibilities": {},
+            "/users/{id}/profile": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/account": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/account/{id}": {},
+            "/users/{id}/profile/addresses": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/addresses/{id}": {},
+            "/users/{id}/profile/anniversaries": {},
+            "/users/{id}/profile/anniversaries/{id}": {},
+            "/users/{id}/profile/awards": {},
+            "/users/{id}/profile/awards/{id}": {},
+            "/users/{id}/profile/certifications": {},
+            "/users/{id}/profile/certifications/{id}": {},
+            "/users/{id}/profile/educationalactivities": {},
+            "/users/{id}/profile/educationalactivities/{id}": {},
+            "/users/{id}/profile/emails": {},
+            "/users/{id}/profile/emails/{id}": {},
+            "/users/{id}/profile/interests": {},
+            "/users/{id}/profile/interests/{id}": {},
+            "/users/{id}/profile/languages": {},
+            "/users/{id}/profile/languages/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/names/{id}": {},
+            "/users/{id}/profile/notes": {},
+            "/users/{id}/profile/patents": {},
+            "/users/{id}/profile/patents/{id}": {},
+            "/users/{id}/profile/phones": {},
+            "/users/{id}/profile/phones/{id}": {},
+            "/users/{id}/profile/positions": {},
+            "/users/{id}/profile/positions/{id}": {},
+            "/users/{id}/profile/projects": {},
+            "/users/{id}/profile/projects/{id}": {},
+            "/users/{id}/profile/publications": {},
+            "/users/{id}/profile/publications/{id}": {},
+            "/users/{id}/profile/skills": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/skills/{id}": {},
+            "/users/{id}/profile/webaccounts": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/webaccounts/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/websites": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/websites/{id}": {},
+            "/users/{id}/responsibilities": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/names": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/names": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/translateexchangeids": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/translateexchangeids": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            }
+          }
+        }
+      ],
+      "ownerEmail": ""
+    },
+    "User.ReadWrite": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Read and write access to user profile",
+          "adminDescription": "Allows the app to read your profile. It also allows the app to update your profile information on your behalf.",
+          "userDisplayName": "Read and update your profile",
+          "userDescription": "Allows the app to read your profile, and discover your group membership, reports and manager. It also allows the app to update your profile information on your behalf.",
+          "requiresAdminConsent": false
+        },
+        "DelegatedPersonal": {
+          "adminDisplayName": "Read and write access to user profile",
+          "adminDescription": "Allows the app to read your profile. It also allows the app to update your profile information on your behalf.",
+          "userDisplayName": "Read and update your profile",
+          "userDescription": "Allows the app to read your profile, and discover your group membership, reports and manager. It also allows the app to update your profile information on your behalf.",
+          "requiresAdminConsent": false
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me": {},
+            "/me/createdobjects": {},
+            "/users/{id}/createdobjects": {}
+          }
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/delta": {},
+            "/users/{id}/usagerights": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/users/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/me/settings/contactmergesuggestions": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/settings/iteminsights": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/settings/contactmergesuggestions": {},
+            "/users/{id}/settings/iteminsights": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/me/invalidateallrefreshtokens": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/validatepassword": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/invalidateallrefreshtokens": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "PATCH",
+            "PUT"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/settings/regionalandlanguagesettings": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "DELETE",
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/notes/{id}": {},
+            "/me/responsibilities/{id}": {},
+            "/users/{id}/profile/notes/{id}": {},
+            "/users/{id}/responsibilities/{id}": {},
+            "/me/profile/account/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/addresses/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/anniversaries/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/awards/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/certifications/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/educationalactivities/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/emails/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/interests/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/languages/{id}": {},
+            "/me/profile/names/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/patents/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/phones/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/positions/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/projects/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/publications/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/skills/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/webaccounts/{id}": {},
+            "/me/profile/websites/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/account/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/addresses/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/anniversaries/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/awards/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/certifications/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/educationalactivities/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/emails/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/interests/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/languages/{id}": {},
+            "/users/{id}/profile/names/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/patents/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/phones/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/positions/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/projects/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/publications/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/skills/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/webaccounts/{id}": {},
+            "/users/{id}/profile/websites/{id}": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "DELETE"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile": {},
+            "/users/{id}/profile": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/account": {},
+            "/me/profile/addresses": {},
+            "/me/profile/anniversaries": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/awards": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/certifications": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/educationalactivities": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/emails": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/interests": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/languages": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/names": {},
+            "/me/profile/notes": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/patents": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/phones": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/positions": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/projects": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/publications": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/me/profile/skills": {},
+            "/me/profile/webaccounts": {},
+            "/me/profile/websites": {},
+            "/me/responsibilities": {},
+            "/users/{id}/profile/account": {},
+            "/users/{id}/profile/addresses": {},
+            "/users/{id}/profile/anniversaries": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/awards": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/certifications": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/educationalactivities": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/emails": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/interests": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/languages": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/names": {},
+            "/users/{id}/profile/notes": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/patents": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/phones": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/positions": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/projects": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/publications": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork",
+                "DelegatedPersonal"
+              ]
+            },
+            "/users/{id}/profile/skills": {},
+            "/users/{id}/profile/webaccounts": {},
+            "/users/{id}/profile/websites": {},
+            "/users/{id}/responsibilities": {}
+          }
+        },
+        {
+          "methods": [
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/me/settings": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/settings": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "PATCH",
+            "PUT"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/{id}/photo": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            },
+            "/me/photo": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/translateexchangeids": {},
+            "/users/{id}/translateexchangeids": {}
+          }
+        }
+      ],
+      "ownerEmail": ""
+    },
+    "User.ReadWrite.All": {
+      "schemes": {
+        "DelegatedWork": {
+          "adminDisplayName": "Read and write all users\u0027 full profiles",
+          "adminDescription": "Allows the app to read and write the full set of profile properties, reports, and managers of other users in your organization, on behalf of the signed-in user.",
+          "userDisplayName": "Read and write all users\u0027 full profiles",
+          "userDescription": "Allows the app to read and write the full set of profile properties, reports, and managers of other users in your organization, on your behalf.",
+          "requiresAdminConsent": true
+        },
+        "Application": {
+          "adminDisplayName": "Read and write all users\u0027 full profiles",
+          "adminDescription": "Allows the app to read and update user profiles without a signed in user.",
+          "requiresAdminConsent": true
+        }
+      },
+      "pathSets": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/directory/deleteditems/microsoft.graph.application": {},
+            "/directory/deleteditems/microsoft.graph.group": {},
+            "/directory/deleteditems/microsoft.graph.serviceprincipal": {},
+            "/directory/deleteditems/microsoft.graph.user": {},
+            "/me": {},
+            "/me/createdobjects": {},
+            "/me/directreports": {},
+            "/me/joinedteams": {},
+            "/me/licensedetails": {},
+            "/me/manager": {},
+            "/me/ownedobjects": {},
+            "/me/registereddevices": {},
+            "/users/delta": {},
+            "/users/{id}/createdobjects": {},
+            "/users/{id}/directreports": {},
+            "/users/{id}/joinedteams": {},
+            "/users/{id}/licensedetails": {},
+            "/users/{id}/owneddevices": {},
+            "/users/{id}/ownedobjects": {},
+            "/users/{id}/registereddevices": {},
+            "/users/{id}/usagerights": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "DELETE"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/directory/deleteditems/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/contacts/{id}/checkmembergroups": {},
+            "/contacts/{id}/checkmemberobjects": {},
+            "/contacts/{id}/getmemberobjects": {},
+            "/devices/{id}/checkmembergroups": {},
+            "/devices/{id}/checkmemberobjects": {},
+            "/devices/{id}/getmemberobjects": {},
+            "/directoryobjects/{id}/checkmembergroups": {},
+            "/directoryobjects/{id}/checkmemberobjects": {},
+            "/directoryobjects/{id}/getmemberobjects": {},
+            "/groups/{id}/checkmembergroups": {},
+            "/groups/{id}/checkmemberobjects": {},
+            "/groups/{id}/getmemberobjects": {},
+            "/me/checkmembergroups": {},
+            "/me/checkmemberobjects": {},
+            "/me/getmemberobjects": {},
+            "/serviceprincipals/{id}/checkmembergroups": {},
+            "/serviceprincipals/{id}/checkmemberobjects": {},
+            "/serviceprincipals/{id}/getmemberobjects": {},
+            "/users/{id}/checkmembergroups": {},
+            "/users/{id}/checkmemberobjects": {},
+            "/users/{id}/getmemberobjects": {},
+            "/directory/deleteditems/{id}/restore": {},
+            "/invitations": {},
+            "/me/revokesigninsessions": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/assignlicense": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/reprocesslicenseassignment": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/users/{id}/revokesigninsessions": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            },
+            "/me/translateexchangeids": {},
+            "/users/{id}/translateexchangeids": {}
+          }
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/directoryobjects/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "PATCH",
+            "DELETE"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/{id}": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "PUT"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/{id}/manager": {
+              "leastPrivilegedPermission": [
+                "Application",
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/organization/{id}/settings/iteminsights": {},
+            "/organization/{id}/settings/peopleinsights": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "PUT"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/{id}/settings/shiftpreferences": {
+              "leastPrivilegedPermission": [
+                "DelegatedWork"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "schemeKeys": [
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/users/validatepassword": {}
+          }
+        },
+        {
+          "methods": [
+            "PATCH",
+            "PUT"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/settings/regionalandlanguagesettings": {}
+          }
+        },
+        {
+          "methods": [
+            "DELETE",
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/notes/{id}": {},
+            "/me/responsibilities/{id}": {},
+            "/users/{id}/profile/notes/{id}": {},
+            "/users/{id}/responsibilities/{id}": {},
+            "/me/profile/account/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/addresses/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/anniversaries/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/awards/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/certifications/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/educationalactivities/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/emails/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/interests/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/languages/{id}": {},
+            "/me/profile/names/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/patents/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/phones/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/positions/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/projects/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/publications/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/skills/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/webaccounts/{id}": {},
+            "/me/profile/websites/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/account/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/addresses/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/anniversaries/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/awards/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/certifications/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/educationalactivities/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/emails/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/interests/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/languages/{id}": {},
+            "/users/{id}/profile/names/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/patents/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/phones/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/positions/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/projects/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/publications/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/skills/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/webaccounts/{id}": {},
+            "/users/{id}/profile/websites/{id}": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "DELETE"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile": {},
+            "/users/{id}/profile": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork",
+            "DelegatedPersonal"
+          ],
+          "paths": {
+            "/me/profile/account": {},
+            "/me/profile/addresses": {},
+            "/me/profile/anniversaries": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/awards": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/certifications": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/educationalactivities": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/emails": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/interests": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/languages": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/names": {},
+            "/me/profile/notes": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/patents": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/phones": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/positions": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/projects": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/publications": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/me/profile/skills": {},
+            "/me/profile/webaccounts": {},
+            "/me/profile/websites": {},
+            "/me/responsibilities": {},
+            "/users/{id}/profile/account": {},
+            "/users/{id}/profile/addresses": {},
+            "/users/{id}/profile/anniversaries": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/awards": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/certifications": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/educationalactivities": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/emails": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/interests": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/languages": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/names": {},
+            "/users/{id}/profile/notes": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/patents": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/phones": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/positions": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/projects": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/publications": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/profile/skills": {},
+            "/users/{id}/profile/webaccounts": {},
+            "/users/{id}/profile/websites": {},
+            "/users/{id}/responsibilities": {}
+          }
+        },
+        {
+          "methods": [
+            "GET",
+            "PATCH"
+          ],
+          "schemeKeys": [
+            "Application",
+            "DelegatedWork"
+          ],
+          "paths": {
+            "/me/settings": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            },
+            "/users/{id}/settings": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            }
+          }
+        },
+        {
+          "methods": [
+            "PATCH",
+            "PUT"
+          ],
+          "schemeKeys": [
+            "Application"
+          ],
+          "paths": {
+            "/users/{id}/photo": {
+              "leastPrivilegedPermission": [
+                "Application"
+              ]
+            }
+          }
+        }
+      ],
+      "ownerEmail": ""
+    }
+  }
+}

--- a/kibaliTests/ValidationTests.cs
+++ b/kibaliTests/ValidationTests.cs
@@ -53,7 +53,7 @@ public class ValidationTests
         authZChecker.Validate(doc);
 
         // Assert
-        Assert.NotEmpty(authZChecker.Errors);
+        Assert.False(authZChecker.ContainsErrors);
     }
     [Fact]
     public void ValidateFolderIsNotValid()
@@ -68,7 +68,7 @@ public class ValidationTests
         // Assert
         Assert.True(authZChecker.ContainsErrors);
         var actualErrors = authZChecker.Errors;
-        Assert.True(actualErrors.Count == 2);
+        Assert.True(actualErrors.Count == 3);
         Assert.Contains(PermissionsErrorCode.DuplicateLeastPrivilegeScopes, actualErrors.Select(e => e.ErrorCode));
         Assert.Contains(PermissionsErrorCode.InvalidLeastPrivilegeScheme, actualErrors.Select(e => e.ErrorCode));
         Assert.Contains("/me", actualErrors.Select(e => e.Path));

--- a/kibaliTests/ValidationTests.cs
+++ b/kibaliTests/ValidationTests.cs
@@ -1,0 +1,78 @@
+﻿using Kibali;
+using Xunit.Abstractions;
+
+namespace KibaliTests;
+
+public class ValidationTests
+{
+    private readonly ITestOutputHelper _output;
+    public ValidationTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+    [Fact]
+    public void ValidateSinglePermissionsFileIsValid()
+    {
+        // Arrange
+        var doc = PermissionsDocument.Load(new FileStream("ValidUser.json", FileMode.Open));
+
+        // Act
+        var authZChecker = new AuthZChecker();
+        authZChecker.Validate(doc);
+        
+        // Assert
+        Assert.False(authZChecker.ContainsErrors);
+    }
+    [Fact]
+    public void ValidateSinglePermissionFileIsNotvalid()
+    {
+        // Arrange
+        var doc = PermissionsDocument.Load(new FileStream("InValidUser.json", FileMode.Open));
+        
+        // Act
+        var authZChecker = new AuthZChecker();
+        authZChecker.Validate(doc);
+
+        // Assert
+        Assert.True(authZChecker.ContainsErrors);
+        var actualErrors = authZChecker.Errors;
+        Assert.True(actualErrors.Count == 2);
+        Assert.Contains(PermissionsErrorCode.DuplicateLeastPrivilegeScopes, actualErrors.Select(e => e.ErrorCode));
+        Assert.Contains(PermissionsErrorCode.InvalidLeastPrivilegeScheme, actualErrors.Select(e => e.ErrorCode));
+        Assert.Contains("/me", actualErrors.Select(e => e.Path));
+        Assert.Contains("/me/createdobjects", actualErrors.Select(e => e.Path)); 
+    }
+    [Fact]
+    public void ValidateFolderIsValid()
+    {
+        // Arrange
+        var doc = PermissionsDocument.LoadAndMerge("ValidPermissions");
+
+        // Act
+        var authZChecker = new AuthZChecker();
+        authZChecker.Validate(doc);
+
+        // Assert
+        Assert.NotEmpty(authZChecker.Errors);
+    }
+    [Fact]
+    public void ValidateFolderIsNotValid()
+    {
+        // Arrange
+        var doc = PermissionsDocument.LoadAndMerge("InvalidPermissions");
+
+        // Act
+        var authZChecker = new AuthZChecker();
+        authZChecker.Validate(doc);
+
+        // Assert
+        Assert.True(authZChecker.ContainsErrors);
+        var actualErrors = authZChecker.Errors;
+        Assert.True(actualErrors.Count == 2);
+        Assert.Contains(PermissionsErrorCode.DuplicateLeastPrivilegeScopes, actualErrors.Select(e => e.ErrorCode));
+        Assert.Contains(PermissionsErrorCode.InvalidLeastPrivilegeScheme, actualErrors.Select(e => e.ErrorCode));
+        Assert.Contains("/me", actualErrors.Select(e => e.Path));
+        Assert.Contains("/users/{id}/licensedetails", actualErrors.Select(e => e.Path));
+    }
+   
+}

--- a/kibaliTool/Program.cs
+++ b/kibaliTool/Program.cs
@@ -27,18 +27,26 @@ namespace KibaliTool
                 QueryCommandBinder.PermissionFileOption,
                 QueryCommandBinder.UrlOption,
                 QueryCommandBinder.MethodOption,
-                QueryCommandBinder.SchemeOption
+                QueryCommandBinder.SchemeOption,
             };
             
             queryCommand.SetHandler(QueryCommand.Execute, new QueryCommandBinder());
             
             Command exportCommand = new Command("export");
-            
+
+            Command validateCommand = new Command("validate") {
+                ValidateCommandBinder.PermissionFileOption,
+                ValidateCommandBinder.PermissionFolderOption,
+            };
+
+            validateCommand.SetHandler(ValidateCommand.Execute, new ValidateCommandBinder());
+
             var rootCommand = new RootCommand()
             {
                 importCommand,
                 queryCommand,
-                exportCommand
+                exportCommand,
+                validateCommand
             };
             
 
@@ -93,7 +101,23 @@ namespace KibaliTool
                 SourcePermissionsFile = bindingContext.ParseResult.GetValueForOption(PermissionFileOption),
                 Url = bindingContext.ParseResult.GetValueForOption(UrlOption),
                 Method = bindingContext.ParseResult.GetValueForOption(MethodOption),
-                Scheme = bindingContext.ParseResult.GetValueForOption(SchemeOption)
+                Scheme = bindingContext.ParseResult.GetValueForOption(SchemeOption),
+            };
+        }
+    }
+
+
+    internal class ValidateCommandBinder : BinderBase<ValidateCommandParameters>
+    {
+        public static Option<string> PermissionFileOption = new(new[] { "--sourcePermissionFile", "--pf" }, "Permission File");
+        public static Option<string> PermissionFolderOption = new(new[] { "--sourcePermissionsFolder", "--fo" }, "Permission Folder");
+
+        protected override ValidateCommandParameters GetBoundValue(BindingContext bindingContext)
+        {
+            return new ValidateCommandParameters()
+            {
+                SourcePermissionsFile = bindingContext.ParseResult.GetValueForOption(PermissionFileOption),
+                SourcePermissionsFolder = bindingContext.ParseResult.GetValueForOption(PermissionFolderOption),
             };
         }
     }

--- a/kibaliTool/ValidateCommand.cs
+++ b/kibaliTool/ValidateCommand.cs
@@ -1,0 +1,38 @@
+﻿using Kibali;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace KibaliTool;
+
+internal class ValidateCommandParameters
+{
+    public string SourcePermissionsFile;
+    public string SourcePermissionsFolder;
+}
+
+internal class ValidateCommand
+{
+    public static async Task<int> Execute(ValidateCommandParameters validateCommandParameters)
+    {
+        var doc = new PermissionsDocument();
+        if (validateCommandParameters.SourcePermissionsFile != null)
+        {
+            using var stream = new FileStream(validateCommandParameters.SourcePermissionsFile, FileMode.Open);
+            doc = PermissionsDocument.Load(stream);
+        }
+        else if (validateCommandParameters.SourcePermissionsFolder != null)
+        {
+            doc = PermissionsDocument.LoadAndMerge(validateCommandParameters.SourcePermissionsFolder);
+        }
+        else
+        {
+            throw new ArgumentException("Please provide a source permissions file or folder");
+        }
+
+        var authZChecker = new AuthZChecker();
+        authZChecker.Validate(doc);
+
+        return 0;
+    }
+}


### PR DESCRIPTION
Adds functionality to validate the entries in the least privileged permissions array. 

- Ensure that the schemes added in the array are the ones in the schemeKeys
- Ensure that we only have one least privileged scope for each (path, method, scheme) combination.